### PR TITLE
feat: T47 sign/verify CLI + architectural boundary hardening

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,27 @@
 # MSRV-aware resolver: fall back rather than hard error on incompatible deps
 [resolver]
 incompatible-rust-versions = "fallback"
+
+[build]
+# Use all available cores
+jobs = -1
+
+[target.'cfg(all())']
+rustflags = [
+    # Enable all clippy pedantic lints
+    "-Wclippy::pedantic",
+    # Deny warnings in CI
+    # "-Dwarnings",
+]
+
+[alias]
+# Quick check without full build
+c = "check --workspace"
+# Build all targets
+b = "build --workspace"
+# Test all
+t = "test --workspace"
+# Clippy profile used in this repository
+l = "clippy --workspace --all-targets -- -W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo -W clippy::perf -A clippy::module_name_repetitions -A clippy::must_use_candidate -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::struct_excessive_bools -A clippy::multiple_crate_versions -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::indexing_slicing -D clippy::cast_ptr_alignment -D clippy::suspicious -D warnings"
+# Full preflight check
+preflight = "run --package preflight-check --"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 - **Analysis report extended** — `AnalysisReport` now includes optional
   `spectral_score` alongside existing detectability metrics
-- **Corpus entry enrichment** — corpus indexing now records
-  `CorpusEntry::spectral_key` when generator profile matching succeeds,
-  enabling resolution-matched model bucketing
+- **Corpus entry enrichment** — `CorpusEntry` now carries an optional
+  `spectral_key` field for future generator-aware enrichment; corpus
+  indexing currently sets it to `None` (bucketing is reserved for a
+  future indexing pass)
 
 ### Refactored
 
@@ -48,7 +49,7 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 ### Testing
 
 - **Spectral/adaptive phase validated** — T36–T40 implementation passed full
-  workspace validation: 430 tests passing, 0 failures, and clippy clean with
+  workspace validation: 453 tests passing, 0 failures, and clippy clean with
   0 warnings
 
 ## [0.2.0] — 2026-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **ML-DSA sign/verify CLI workflows** — `keygen sign` and `keygen verify`
   subcommands exposed, enabling signing arbitrary payloads and verifying
   detached ML-DSA-87 signatures directly from the CLI
-
-### Refactored
-
-- **Geographic distribution boundary hardened** — `DistributeService` now
-  exposes `distribute_with_geographic_manifest`, routing geo-threshold
-  distribution through the application service layer rather than calling the
-  adapter port directly from the runner; eliminates an interface→adapter
-  boundary violation
-
----
-
-### Added
-
 - **Spectral adaptive embedding primitives** — introduced AI-generator-aware
   profile vocabulary (`AiGenProfile`, `CarrierBin`, `CoverProfile`,
   `SpectralKey`) to model known FFT carrier regions and resolution-specific
@@ -49,6 +36,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - **Corpus entry enrichment** — corpus indexing now records
   `CorpusEntry::spectral_key` when generator profile matching succeeds,
   enabling resolution-matched model bucketing
+
+### Refactored
+
+- **Geographic distribution boundary hardened** — `DistributeService` now
+  exposes `distribute_with_geographic_manifest`, routing geo-threshold
+  distribution through the application service layer rather than calling the
+  adapter port directly from the runner; eliminates an interface→adapter
+  boundary violation
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **ML-DSA sign/verify CLI workflows** — `keygen sign` and `keygen verify`
+  subcommands exposed, enabling signing arbitrary payloads and verifying
+  detached ML-DSA-87 signatures directly from the CLI
+
+### Refactored
+
+- **Geographic distribution boundary hardened** — `DistributeService` now
+  exposes `distribute_with_geographic_manifest`, routing geo-threshold
+  distribution through the application service layer rather than calling the
+  adapter port directly from the runner; eliminates an interface→adapter
+  boundary violation
+
+---
+
+### Added
+
 - **Spectral adaptive embedding primitives** — introduced AI-generator-aware
   profile vocabulary (`AiGenProfile`, `CarrierBin`, `CoverProfile`,
   `SpectralKey`) to model known FFT carrier regions and resolution-specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Spectral adaptive embedding primitives** — introduced AI-generator-aware
+  profile vocabulary (`AiGenProfile`, `CarrierBin`, `CoverProfile`,
+  `SpectralKey`) to model known FFT carrier regions and resolution-specific
+  watermark behavior
+- **Adaptive bounded context implementation** — added
+  `domain/adaptive/mod.rs` with frequency-bin masking and STC-inspired
+  permutation search (`BinMask`, `SearchConfig`, `permutation_search`)
+- **Adaptive adapter implementations** — added `AdaptiveOptimiserImpl`,
+  `CoverProfileMatcherImpl`, and `CompressionSimulatorImpl` with bundled AI
+  profile codebook support
+- **Corpus spectral secondary index** — `CorpusIndex` now supports
+  model-aware lookup via `search_for_model` and index introspection via
+  `model_stats`
+- **Corpus CLI model filtering** — `corpus search` now accepts optional
+  `--model` and `--resolution` filters for generator-aware cover selection
+
+### Changed
+
+- **Analysis report extended** — `AnalysisReport` now includes optional
+  `spectral_score` alongside existing detectability metrics
+- **Corpus entry enrichment** — corpus indexing now records
+  `CorpusEntry::spectral_key` when generator profile matching succeeds,
+  enabling resolution-matched model bucketing
+
+### Testing
+
+- **Spectral/adaptive phase validated** — T36–T40 implementation passed full
+  workspace validation: 430 tests passing, 0 failures, and clippy clean with
+  0 warnings
+
 ## [0.2.0] — 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1801,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -2094,6 +2112,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2331,7 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "rstest",
+ "rustfft",
  "serde",
  "serde_json",
  "sha2",
@@ -2376,6 +2409,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "stringprep"
@@ -2662,6 +2701,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ dependencies = [
  "md-5",
  "nom",
  "nom_locate",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rangemap",
  "rayon",
  "sha2",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2325,7 +2325,7 @@ dependencies = [
  "pdfium-render",
  "predicates",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_chacha 0.10.0",
  "rand_core 0.10.0",
  "rayon",
@@ -2468,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,20 @@ debug    = true
 
 [profile.dev]
 opt-level = 1 # slightly optimised dev builds for crypto perf
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+missing_docs = "warn"
+unused_must_use = "deny"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+expect_used = "deny"
+unwrap_used = "deny"
+indexing_slicing = "deny"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+multiple_crate_versions = "allow"

--- a/crates/shadowforge/Cargo.toml
+++ b/crates/shadowforge/Cargo.toml
@@ -133,22 +133,5 @@ adaptive = [] # pure Rust scoring functions
 simd     = ["reed-solomon-erasure/simd-accel"]
 
 # ─── Lints ────────────────────────────────────────────────────────────────────
-[lints.rust]
-unsafe_code       = "forbid"
-missing_docs      = "warn"
-unused_must_use   = "deny"
-
-[lints.clippy]
-pedantic          = { level = "warn", priority = -1 }
-nursery           = { level = "warn", priority = -1 }
-# Restriction lints — zero panics in production AND test code
-expect_used       = "deny"
-unwrap_used       = "deny"
-indexing_slicing   = "deny"
-# Allow common false-positives from pedantic
-module_name_repetitions = "allow"
-must_use_candidate      = "allow"
-missing_errors_doc      = "allow"
-missing_panics_doc      = "allow"
-# Transitive dependency version duplication — outside our control
-multiple_crate_versions = "allow"
+[lints]
+workspace = true

--- a/crates/shadowforge/Cargo.toml
+++ b/crates/shadowforge/Cargo.toml
@@ -51,6 +51,9 @@ num-traits = "0.2"
 # ─── Error Correction ─────────────────────────────────────────────────────────
 reed-solomon-erasure = { version = "6.0", features = ["simd-accel"] }
 
+# ─── FFT ──────────────────────────────────────────────────────────────────────
+rustfft = "6"
+
 # ─── Serialisation ────────────────────────────────────────────────────────────
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/shadowforge/src/adapters/adaptive.rs
+++ b/crates/shadowforge/src/adapters/adaptive.rs
@@ -1,0 +1,533 @@
+//! Adaptive embedding adapters: cover-profile matching, STC-inspired
+//! optimisation, and platform compression simulation.
+//!
+//! I/O is allowed here; domain logic lives in `domain/adaptive`.
+
+use std::io::Cursor;
+use std::sync::LazyLock;
+
+use bytes::Bytes;
+use rustfft::FftPlanner;
+use rustfft::num_complex::Complex;
+use serde::Deserialize;
+
+use crate::domain::adaptive::{BinMask, SearchConfig, permutation_search};
+use crate::domain::errors::AdaptiveError;
+use crate::domain::ports::{
+    AdaptiveOptimiser, AiGenProfile, CameraProfile, CompressionSimulator, CoverProfile,
+    CoverProfileMatcher,
+};
+use crate::domain::types::{Capacity, CoverMedia, CoverMediaKind, PlatformProfile, StegoTechnique};
+
+// ─── Built-in AI codebook ────────────────────────────────────────────────────
+
+/// Deserialisation wrapper for `ai_profiles.json`.
+#[derive(Deserialize)]
+struct ProfileCodebook {
+    profiles: Vec<AiGenProfile>,
+}
+
+// ─── CoverProfileMatcherImpl ─────────────────────────────────────────────────
+
+/// Concrete cover-profile matcher.
+///
+/// Loaded from a JSON codebook at construction time.  The built-in codebook
+/// includes the Gemini watermark profile.
+pub struct CoverProfileMatcherImpl {
+    ai_profiles: Vec<AiGenProfile>,
+    camera_profiles: Vec<CameraProfile>,
+}
+
+impl CoverProfileMatcherImpl {
+    /// Parse an AI profile codebook from a JSON string.
+    ///
+    /// # Errors
+    /// Returns [`AdaptiveError::ProfileMatchFailed`] if the JSON is malformed.
+    pub fn from_codebook(json: &str) -> Result<Self, AdaptiveError> {
+        let book: ProfileCodebook =
+            serde_json::from_str(json).map_err(|e| AdaptiveError::ProfileMatchFailed {
+                reason: format!("invalid codebook JSON: {e}"),
+            })?;
+        Ok(Self {
+            ai_profiles: book.profiles,
+            camera_profiles: Vec::new(),
+        })
+    }
+
+    /// Build using the built-in `ai_profiles.json` codebook bundled at
+    /// compile time.
+    ///
+    /// # Panics
+    ///
+    /// Never panics in production — the embedded JSON is validated at
+    /// compile-time test level.
+    #[must_use]
+    pub fn with_built_in() -> Self {
+        static BUILT_IN: LazyLock<Vec<AiGenProfile>> = LazyLock::new(|| {
+            let raw = include_str!("ai_profiles.json");
+            let book: ProfileCodebook =
+                serde_json::from_str(raw).expect("bundled ai_profiles.json must be valid JSON");
+            book.profiles
+        });
+        Self {
+            ai_profiles: BUILT_IN.clone(),
+            camera_profiles: Vec::new(),
+        }
+    }
+}
+
+impl CoverProfileMatcher for CoverProfileMatcherImpl {
+    fn profile_for(&self, cover: &CoverMedia) -> Option<CoverProfile> {
+        // Only images can be matched.
+        let width = cover
+            .metadata
+            .get("width")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        let height = cover
+            .metadata
+            .get("height")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+
+        if width == 0 || height == 0 {
+            return None;
+        }
+
+        let pixels = extract_green_f32(&cover.data, width, height);
+        if pixels.len() < 4 {
+            return None;
+        }
+
+        let fft_len = pixels.len().next_power_of_two();
+        let freq = fft_1d(&pixels, fft_len);
+
+        // Try each AI profile — pick the one with the most coherent carriers.
+        let best_ai = self.ai_profiles.iter().max_by_key(|p| {
+            let bins = p.carrier_bins_for(width, height).unwrap_or(&[]);
+            let strong_count = bins
+                .iter()
+                .filter(|b| b.is_strong())
+                .filter(|b| {
+                    let idx = b.freq.1 as usize;
+                    if let Some(c) = freq.get(idx) {
+                        // Phase within π/8 of expected.
+                        let phase_diff = (c.arg() as f64 - b.phase).abs();
+                        phase_diff < std::f64::consts::PI / 8.0
+                    } else {
+                        false
+                    }
+                })
+                .count();
+            strong_count
+        });
+
+        if let Some(profile) = best_ai {
+            let bins = profile.carrier_bins_for(width, height).unwrap_or(&[]);
+            let matching: usize = bins
+                .iter()
+                .filter(|b| b.is_strong())
+                .filter(|b| {
+                    let idx = b.freq.1 as usize;
+                    freq.get(idx).map_or(false, |c| {
+                        (c.arg() as f64 - b.phase).abs() < std::f64::consts::PI / 8.0
+                    })
+                })
+                .count();
+            // Require at least half the strong bins to match.
+            let strong_total = bins.iter().filter(|b| b.is_strong()).count();
+            if matching >= strong_total.saturating_sub(1).max(1) {
+                return Some(CoverProfile::AiGenerator(profile.clone()));
+            }
+        }
+
+        // Fallback: camera profile if any are loaded.
+        self.camera_profiles
+            .first()
+            .cloned()
+            .map(CoverProfile::Camera)
+    }
+
+    fn apply_profile(
+        &self,
+        cover: CoverMedia,
+        _profile: &CoverProfile,
+    ) -> Result<CoverMedia, AdaptiveError> {
+        // For AI profiles: no modification — the optimiser avoids carrier bins.
+        // For camera profiles: a real implementation would adjust quant tables
+        // via the JPEG encoder; stub returns cover unchanged.
+        Ok(cover)
+    }
+}
+
+// ─── AdaptiveOptimiserImpl ───────────────────────────────────────────────────
+
+/// Concrete adversarial optimiser.
+///
+/// Uses `permutation_search` from `domain/adaptive` to find a byte-reordering
+/// that minimises chi-square detectability.
+pub struct AdaptiveOptimiserImpl {
+    matcher: CoverProfileMatcherImpl,
+    config: SearchConfig,
+}
+
+impl AdaptiveOptimiserImpl {
+    /// Create with an explicit codebook and search configuration.
+    ///
+    /// # Errors
+    /// Returns [`AdaptiveError::ProfileMatchFailed`] if the codebook is invalid.
+    pub fn from_codebook(codebook_json: &str, config: SearchConfig) -> Result<Self, AdaptiveError> {
+        Ok(Self {
+            matcher: CoverProfileMatcherImpl::from_codebook(codebook_json)?,
+            config,
+        })
+    }
+
+    /// Create with the built-in Gemini codebook and default search config.
+    #[must_use]
+    pub fn with_built_in() -> Self {
+        Self {
+            matcher: CoverProfileMatcherImpl::with_built_in(),
+            config: SearchConfig::default(),
+        }
+    }
+}
+
+impl AdaptiveOptimiser for AdaptiveOptimiserImpl {
+    fn optimise(
+        &self,
+        mut stego: CoverMedia,
+        _original: &CoverMedia,
+        target_db: f64,
+    ) -> Result<CoverMedia, AdaptiveError> {
+        let width = stego
+            .metadata
+            .get("width")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1);
+        let height = stego
+            .metadata
+            .get("height")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1);
+
+        let profile = self.matcher.profile_for(&stego);
+        let mask = BinMask::build(
+            profile
+                .as_ref()
+                .unwrap_or(&CoverProfile::Camera(CameraProfile {
+                    quantisation_table: vec![],
+                    noise_floor_db: -80.0,
+                    model_id: "fallback".to_string(),
+                })),
+            width,
+            height,
+        );
+
+        let config = SearchConfig {
+            max_iterations: self.config.max_iterations,
+            target_db,
+        };
+
+        // Derive deterministic seed from first 8 bytes of the stego data.
+        let seed = stego
+            .data
+            .get(..8)
+            .map(|b| u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+            .unwrap_or(0);
+
+        let mut data = stego.data.to_vec();
+        let perm = permutation_search(&data, &mask, &config, seed);
+        perm.apply(&mut data);
+        stego.data = Bytes::from(data);
+        Ok(stego)
+    }
+}
+
+// ─── CompressionSimulatorImpl ────────────────────────────────────────────────
+
+/// Platform-specific quality and chroma settings.
+#[derive(Debug, Clone, Copy)]
+struct PlatformSettings {
+    jpeg_quality: u8,
+    /// Minimum capacity that survives recompression (bytes, rough estimate).
+    survivable_fraction: f64,
+}
+
+impl PlatformSettings {
+    const fn for_platform(platform: &PlatformProfile) -> Self {
+        match platform {
+            PlatformProfile::Instagram => Self {
+                jpeg_quality: 82,
+                survivable_fraction: 0.40,
+            },
+            PlatformProfile::Twitter => Self {
+                jpeg_quality: 75,
+                survivable_fraction: 0.30,
+            },
+            PlatformProfile::WhatsApp => Self {
+                jpeg_quality: 85,
+                survivable_fraction: 0.45,
+            },
+            PlatformProfile::Telegram => Self {
+                jpeg_quality: 95,
+                survivable_fraction: 0.70,
+            },
+            PlatformProfile::Imgur => Self {
+                jpeg_quality: 85,
+                survivable_fraction: 0.45,
+            },
+            PlatformProfile::Custom { quality, .. } => Self {
+                jpeg_quality: *quality,
+                survivable_fraction: 0.40,
+            },
+        }
+    }
+}
+
+/// Compression simulator using the `image` crate for in-memory JPEG encode/
+/// decode.  No temporary files are used — bytes flow through a `Cursor`.
+pub struct CompressionSimulatorImpl;
+
+impl CompressionSimulator for CompressionSimulatorImpl {
+    fn simulate(
+        &self,
+        cover: CoverMedia,
+        platform: &PlatformProfile,
+    ) -> Result<CoverMedia, AdaptiveError> {
+        let settings = PlatformSettings::for_platform(platform);
+        let quality = settings.jpeg_quality;
+
+        let width = cover
+            .metadata
+            .get("width")
+            .and_then(|v| v.parse::<u32>().ok());
+        let height = cover
+            .metadata
+            .get("height")
+            .and_then(|v| v.parse::<u32>().ok());
+
+        // We can only JPEG-compress actual image data.  If we lack dimensions
+        // or the cover isn't an image type, return unchanged.
+        let (Some(w), Some(h)) = (width, height) else {
+            return Ok(cover);
+        };
+
+        if !matches!(
+            cover.kind,
+            CoverMediaKind::PngImage
+                | CoverMediaKind::JpegImage
+                | CoverMediaKind::BmpImage
+                | CoverMediaKind::GifImage
+        ) {
+            return Ok(cover);
+        }
+
+        // Treat raw data as RGBA8 pixels.
+        let pixels = cover.data.to_vec();
+        let expected_len = (w as usize).saturating_mul(h as usize).saturating_mul(3);
+        if pixels.len() < expected_len {
+            return Ok(cover);
+        }
+
+        // Encode as JPEG into memory.
+        let mut encoded: Vec<u8> = Vec::new();
+        {
+            let mut cursor = Cursor::new(&mut encoded);
+            let mut encoder =
+                image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, quality);
+            image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w, h, &pixels[..expected_len])
+                .ok_or_else(|| AdaptiveError::CompressionSimFailed {
+                    reason: "invalid pixel dimensions".to_string(),
+                })
+                .and_then(|buf| {
+                    encoder
+                        .encode(buf.as_raw(), w, h, image::ExtendedColorType::Rgb8)
+                        .map_err(|e| AdaptiveError::CompressionSimFailed {
+                            reason: format!("JPEG encode failed: {e}"),
+                        })
+                })?;
+        }
+
+        // Decode back.
+        let decoded = image::load_from_memory_with_format(&encoded, image::ImageFormat::Jpeg)
+            .map_err(|e| AdaptiveError::CompressionSimFailed {
+                reason: format!("JPEG decode failed: {e}"),
+            })?;
+        let rgb = decoded.to_rgb8();
+        let mut out_meta = cover.metadata.clone();
+        out_meta.insert("width".to_string(), w.to_string());
+        out_meta.insert("height".to_string(), h.to_string());
+
+        Ok(CoverMedia {
+            kind: CoverMediaKind::JpegImage,
+            data: Bytes::from(rgb.into_raw()),
+            metadata: out_meta,
+        })
+    }
+
+    fn survivable_capacity(
+        &self,
+        cover: &CoverMedia,
+        platform: &PlatformProfile,
+    ) -> Result<Capacity, AdaptiveError> {
+        let settings = PlatformSettings::for_platform(platform);
+        let total_bytes = cover.data.len() as u64;
+        let survivable = ((total_bytes as f64) * settings.survivable_fraction) as u64;
+        Ok(Capacity {
+            bytes: survivable,
+            technique: StegoTechnique::LsbImage,
+        })
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn extract_green_f32(data: &Bytes, width: u32, height: u32) -> Vec<f32> {
+    let expected = (width as usize)
+        .saturating_mul(height as usize)
+        .saturating_mul(4);
+    if data.len() >= expected {
+        // RGBA8
+        data.chunks_exact(4).map(|ch| ch[1] as f32).collect()
+    } else if data.len()
+        >= (width as usize)
+            .saturating_mul(height as usize)
+            .saturating_mul(3)
+    {
+        // RGB8
+        data.chunks_exact(3).map(|ch| ch[1] as f32).collect()
+    } else {
+        data.iter().map(|&b| b as f32).collect()
+    }
+}
+
+fn fft_1d(samples: &[f32], fft_len: usize) -> Vec<Complex<f32>> {
+    let mut input: Vec<Complex<f32>> = samples.iter().map(|&x| Complex::new(x, 0.0)).collect();
+    input.resize(fft_len, Complex::new(0.0, 0.0));
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(fft_len);
+    fft.process(&mut input);
+    input
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_cover(kind: CoverMediaKind, w: u32, h: u32) -> CoverMedia {
+        let n = (w as usize).saturating_mul(h as usize).saturating_mul(4);
+        let mut meta = HashMap::new();
+        meta.insert("width".to_string(), w.to_string());
+        meta.insert("height".to_string(), h.to_string());
+        CoverMedia {
+            kind,
+            data: Bytes::from(vec![128u8; n]),
+            metadata: meta,
+        }
+    }
+
+    #[test]
+    fn built_in_codebook_parses_without_error() {
+        let matcher = CoverProfileMatcherImpl::with_built_in();
+        assert!(!matcher.ai_profiles.is_empty());
+        assert_eq!(matcher.ai_profiles[0].model_id, "gemini");
+    }
+
+    #[test]
+    fn from_codebook_returns_error_on_bad_json() {
+        let result = CoverProfileMatcherImpl::from_codebook("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_codebook_accepts_valid_json() {
+        let json = r#"{"profiles":[{"model_id":"test","channel_weights":[1.0,1.0,1.0],"carrier_map":{}}]}"#;
+        let result = CoverProfileMatcherImpl::from_codebook(json);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn profile_for_returns_none_for_zero_dimensions() {
+        let matcher = CoverProfileMatcherImpl::with_built_in();
+        let cover = CoverMedia {
+            kind: CoverMediaKind::PngImage,
+            data: Bytes::from(vec![0u8; 16]),
+            metadata: HashMap::new(), // no width/height
+        };
+        assert!(matcher.profile_for(&cover).is_none());
+    }
+
+    #[test]
+    fn apply_profile_returns_cover_unchanged() {
+        let matcher = CoverProfileMatcherImpl::with_built_in();
+        let cover = make_cover(CoverMediaKind::PngImage, 8, 8);
+        let profile = CoverProfile::Camera(CameraProfile {
+            quantisation_table: vec![0u16; 64],
+            noise_floor_db: -80.0,
+            model_id: "test".to_string(),
+        });
+        let result = matcher.apply_profile(cover.clone(), &profile).unwrap();
+        assert_eq!(result.data, cover.data);
+    }
+
+    #[test]
+    fn adaptive_optimiser_built_in_runs_without_error() {
+        let optimiser = AdaptiveOptimiserImpl::with_built_in();
+        let cover = make_cover(CoverMediaKind::PngImage, 8, 8);
+        let stego = make_cover(CoverMediaKind::PngImage, 8, 8);
+        let result = optimiser.optimise(stego, &cover, -12.0);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn adaptive_optimiser_preserves_data_length() {
+        let optimiser = AdaptiveOptimiserImpl::with_built_in();
+        let cover = make_cover(CoverMediaKind::PngImage, 4, 4);
+        let stego = make_cover(CoverMediaKind::PngImage, 4, 4);
+        let original_len = stego.data.len();
+        let result = optimiser.optimise(stego, &cover, -12.0).unwrap();
+        assert_eq!(result.data.len(), original_len);
+    }
+
+    #[test]
+    fn compression_simulator_survivable_capacity() {
+        let sim = CompressionSimulatorImpl;
+        let cover = make_cover(CoverMediaKind::PngImage, 32, 32);
+        let cap = sim
+            .survivable_capacity(&cover, &PlatformProfile::Instagram)
+            .unwrap();
+        assert!(cap.bytes > 0);
+        assert!(cap.bytes < cover.data.len() as u64);
+    }
+
+    #[test]
+    fn compression_simulator_non_image_returns_unchanged() {
+        let sim = CompressionSimulatorImpl;
+        let cover = CoverMedia {
+            kind: CoverMediaKind::WavAudio,
+            data: Bytes::from(vec![0u8; 1024]),
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert("width".to_string(), "32".to_string());
+                m.insert("height".to_string(), "32".to_string());
+                m
+            },
+        };
+        let result = sim
+            .simulate(cover.clone(), &PlatformProfile::Twitter)
+            .unwrap();
+        assert_eq!(result.data, cover.data);
+    }
+
+    #[test]
+    fn platform_settings_telegram_highest_quality() {
+        let t = PlatformSettings::for_platform(&PlatformProfile::Telegram);
+        let i = PlatformSettings::for_platform(&PlatformProfile::Twitter);
+        assert!(t.jpeg_quality > i.jpeg_quality);
+        assert!(t.survivable_fraction > i.survivable_fraction);
+    }
+}

--- a/crates/shadowforge/src/adapters/adaptive.rs
+++ b/crates/shadowforge/src/adapters/adaptive.rs
@@ -366,6 +366,30 @@ impl CompressionSimulator for CompressionSimulatorImpl {
     }
 }
 
+// ─── Dependency factory ───────────────────────────────────────────────────────
+
+/// Construct the three built-in adaptive adapters that together form the
+/// default profile-hardening dependency set.
+///
+/// Call sites should keep the returned values alive for as long as an
+/// [`crate::application::services::AdaptiveProfileDeps`] that borrows them
+/// is in scope.
+///
+/// Placing this factory in the adapter layer keeps the interface layer free
+/// from knowing *which* concrete types implement the adaptive port traits.
+#[must_use]
+pub fn build_adaptive_profile_deps() -> (
+    CoverProfileMatcherImpl,
+    AdaptiveOptimiserImpl,
+    CompressionSimulatorImpl,
+) {
+    (
+        CoverProfileMatcherImpl::with_built_in(),
+        AdaptiveOptimiserImpl::with_built_in(),
+        CompressionSimulatorImpl,
+    )
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 fn extract_green_f32(data: &Bytes, width: u32, height: u32) -> Vec<f32> {
@@ -551,5 +575,12 @@ mod tests {
             return;
         };
         assert!(t_cap.bytes > i_cap.bytes);
+    }
+
+    #[test]
+    fn build_adaptive_profile_deps_returns_functional_impls() {
+        let (matcher, _optimiser, _compressor) = build_adaptive_profile_deps();
+        // The matcher must have loaded the built-in codebook.
+        assert!(!matcher.ai_profiles.is_empty());
     }
 }

--- a/crates/shadowforge/src/adapters/adaptive.rs
+++ b/crates/shadowforge/src/adapters/adaptive.rs
@@ -65,8 +65,16 @@ impl CoverProfileMatcherImpl {
     pub fn with_built_in() -> Self {
         static BUILT_IN: LazyLock<Vec<AiGenProfile>> = LazyLock::new(|| {
             let raw = include_str!("ai_profiles.json");
-            serde_json::from_str::<ProfileCodebook>(raw)
-                .map_or_else(|_| Vec::new(), |book| book.profiles)
+            match serde_json::from_str::<ProfileCodebook>(raw) {
+                Ok(book) => book.profiles,
+                Err(e) => {
+                    tracing::error!(
+                        "built-in AI profile codebook is malformed — \
+                         adaptive matching is disabled: {e}"
+                    );
+                    Vec::new()
+                }
+            }
         });
         Self {
             ai_profiles: BUILT_IN.clone(),
@@ -107,7 +115,7 @@ impl CoverProfileMatcher for CoverProfileMatcherImpl {
             bins.iter()
                 .filter(|b| b.is_strong())
                 .filter(|b| {
-                    let idx = b.freq.1 as usize;
+                    let idx = b.freq.0 as usize * width as usize + b.freq.1 as usize;
                     // Phase within π/8 of expected.
                     freq.get(idx).is_some_and(|c| {
                         let phase_diff = (f64::from(c.arg()) - b.phase).abs();
@@ -125,7 +133,7 @@ impl CoverProfileMatcher for CoverProfileMatcherImpl {
                 .iter()
                 .filter(|b| b.is_strong())
                 .filter(|b| {
-                    let idx = b.freq.1 as usize;
+                    let idx = b.freq.0 as usize * width as usize + b.freq.1 as usize;
                     freq.get(idx).is_some_and(|c| {
                         (f64::from(c.arg()) - b.phase).abs() < std::f64::consts::PI / 8.0
                     })
@@ -210,7 +218,7 @@ impl AdaptiveOptimiser for AdaptiveOptimiserImpl {
 
         let profile = self.matcher.profile_for(&stego);
         let fallback_profile = CoverProfile::Camera(CameraProfile {
-            quantisation_table: vec![],
+            quantisation_table: [0u16; 64],
             noise_floor_db: -80.0,
             model_id: "fallback".to_string(),
         });
@@ -487,7 +495,7 @@ mod tests {
         let matcher = CoverProfileMatcherImpl::with_built_in();
         let cover = make_cover(CoverMediaKind::PngImage, 8, 8);
         let profile = CoverProfile::Camera(CameraProfile {
-            quantisation_table: vec![0u16; 64],
+            quantisation_table: [0u16; 64],
             noise_floor_db: -80.0,
             model_id: "test".to_string(),
         });

--- a/crates/shadowforge/src/adapters/adaptive.rs
+++ b/crates/shadowforge/src/adapters/adaptive.rs
@@ -65,9 +65,8 @@ impl CoverProfileMatcherImpl {
     pub fn with_built_in() -> Self {
         static BUILT_IN: LazyLock<Vec<AiGenProfile>> = LazyLock::new(|| {
             let raw = include_str!("ai_profiles.json");
-            let book: ProfileCodebook =
-                serde_json::from_str(raw).expect("bundled ai_profiles.json must be valid JSON");
-            book.profiles
+            serde_json::from_str::<ProfileCodebook>(raw)
+                .map_or_else(|_| Vec::new(), |book| book.profiles)
         });
         Self {
             ai_profiles: BUILT_IN.clone(),
@@ -104,33 +103,31 @@ impl CoverProfileMatcher for CoverProfileMatcherImpl {
 
         // Try each AI profile — pick the one with the most coherent carriers.
         let best_ai = self.ai_profiles.iter().max_by_key(|p| {
-            let bins = p.carrier_bins_for(width, height).unwrap_or(&[]);
-            let strong_count = bins
-                .iter()
+            let bins = p.carrier_bins_for(width, height).map_or(&[][..], |v| v);
+            bins.iter()
                 .filter(|b| b.is_strong())
                 .filter(|b| {
                     let idx = b.freq.1 as usize;
-                    if let Some(c) = freq.get(idx) {
-                        // Phase within π/8 of expected.
-                        let phase_diff = (c.arg() as f64 - b.phase).abs();
+                    // Phase within π/8 of expected.
+                    freq.get(idx).is_some_and(|c| {
+                        let phase_diff = (f64::from(c.arg()) - b.phase).abs();
                         phase_diff < std::f64::consts::PI / 8.0
-                    } else {
-                        false
-                    }
+                    })
                 })
-                .count();
-            strong_count
+                .count()
         });
 
         if let Some(profile) = best_ai {
-            let bins = profile.carrier_bins_for(width, height).unwrap_or(&[]);
+            let bins = profile
+                .carrier_bins_for(width, height)
+                .map_or(&[][..], |v| v);
             let matching: usize = bins
                 .iter()
                 .filter(|b| b.is_strong())
                 .filter(|b| {
                     let idx = b.freq.1 as usize;
-                    freq.get(idx).map_or(false, |c| {
-                        (c.arg() as f64 - b.phase).abs() < std::f64::consts::PI / 8.0
+                    freq.get(idx).is_some_and(|c| {
+                        (f64::from(c.arg()) - b.phase).abs() < std::f64::consts::PI / 8.0
                     })
                 })
                 .count();
@@ -212,17 +209,12 @@ impl AdaptiveOptimiser for AdaptiveOptimiserImpl {
             .unwrap_or(1);
 
         let profile = self.matcher.profile_for(&stego);
-        let mask = BinMask::build(
-            profile
-                .as_ref()
-                .unwrap_or(&CoverProfile::Camera(CameraProfile {
-                    quantisation_table: vec![],
-                    noise_floor_db: -80.0,
-                    model_id: "fallback".to_string(),
-                })),
-            width,
-            height,
-        );
+        let fallback_profile = CoverProfile::Camera(CameraProfile {
+            quantisation_table: vec![],
+            noise_floor_db: -80.0,
+            model_id: "fallback".to_string(),
+        });
+        let mask = BinMask::build(profile.as_ref().unwrap_or(&fallback_profile), width, height);
 
         let config = SearchConfig {
             max_iterations: self.config.max_iterations,
@@ -230,11 +222,14 @@ impl AdaptiveOptimiser for AdaptiveOptimiserImpl {
         };
 
         // Derive deterministic seed from first 8 bytes of the stego data.
-        let seed = stego
-            .data
-            .get(..8)
-            .map(|b| u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
-            .unwrap_or(0);
+        let seed = stego.data.get(..8).map_or_else(
+            || 0,
+            |bytes| {
+                let mut seed_bytes = [0u8; 8];
+                seed_bytes.copy_from_slice(bytes);
+                u64::from_le_bytes(seed_bytes)
+            },
+        );
 
         let mut data = stego.data.to_vec();
         let perm = permutation_search(&data, &mask, &config, seed);
@@ -250,36 +245,17 @@ impl AdaptiveOptimiser for AdaptiveOptimiserImpl {
 #[derive(Debug, Clone, Copy)]
 struct PlatformSettings {
     jpeg_quality: u8,
-    /// Minimum capacity that survives recompression (bytes, rough estimate).
-    survivable_fraction: f64,
 }
 
 impl PlatformSettings {
     const fn for_platform(platform: &PlatformProfile) -> Self {
         match platform {
-            PlatformProfile::Instagram => Self {
-                jpeg_quality: 82,
-                survivable_fraction: 0.40,
-            },
-            PlatformProfile::Twitter => Self {
-                jpeg_quality: 75,
-                survivable_fraction: 0.30,
-            },
-            PlatformProfile::WhatsApp => Self {
-                jpeg_quality: 85,
-                survivable_fraction: 0.45,
-            },
-            PlatformProfile::Telegram => Self {
-                jpeg_quality: 95,
-                survivable_fraction: 0.70,
-            },
-            PlatformProfile::Imgur => Self {
-                jpeg_quality: 85,
-                survivable_fraction: 0.45,
-            },
+            PlatformProfile::Instagram => Self { jpeg_quality: 82 },
+            PlatformProfile::Twitter => Self { jpeg_quality: 75 },
+            PlatformProfile::WhatsApp | PlatformProfile::Imgur => Self { jpeg_quality: 85 },
+            PlatformProfile::Telegram => Self { jpeg_quality: 95 },
             PlatformProfile::Custom { quality, .. } => Self {
                 jpeg_quality: *quality,
-                survivable_fraction: 0.40,
             },
         }
     }
@@ -334,19 +310,23 @@ impl CompressionSimulator for CompressionSimulatorImpl {
         let mut encoded: Vec<u8> = Vec::new();
         {
             let mut cursor = Cursor::new(&mut encoded);
-            let mut encoder =
+            let mut jpeg_encoder =
                 image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, quality);
-            image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w, h, &pixels[..expected_len])
-                .ok_or_else(|| AdaptiveError::CompressionSimFailed {
-                    reason: "invalid pixel dimensions".to_string(),
-                })
-                .and_then(|buf| {
-                    encoder
-                        .encode(buf.as_raw(), w, h, image::ExtendedColorType::Rgb8)
-                        .map_err(|e| AdaptiveError::CompressionSimFailed {
-                            reason: format!("JPEG encode failed: {e}"),
-                        })
-                })?;
+            image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(
+                w,
+                h,
+                pixels.get(..expected_len).unwrap_or(&[]),
+            )
+            .ok_or_else(|| AdaptiveError::CompressionSimFailed {
+                reason: "invalid pixel dimensions".to_string(),
+            })
+            .and_then(|buf| {
+                jpeg_encoder
+                    .encode(buf.as_raw(), w, h, image::ExtendedColorType::Rgb8)
+                    .map_err(|e| AdaptiveError::CompressionSimFailed {
+                        reason: format!("JPEG encode failed: {e}"),
+                    })
+            })?;
         }
 
         // Decode back.
@@ -355,7 +335,7 @@ impl CompressionSimulator for CompressionSimulatorImpl {
                 reason: format!("JPEG decode failed: {e}"),
             })?;
         let rgb = decoded.to_rgb8();
-        let mut out_meta = cover.metadata.clone();
+        let mut out_meta = cover.metadata;
         out_meta.insert("width".to_string(), w.to_string());
         out_meta.insert("height".to_string(), h.to_string());
 
@@ -371,9 +351,14 @@ impl CompressionSimulator for CompressionSimulatorImpl {
         cover: &CoverMedia,
         platform: &PlatformProfile,
     ) -> Result<Capacity, AdaptiveError> {
-        let settings = PlatformSettings::for_platform(platform);
         let total_bytes = cover.data.len() as u64;
-        let survivable = ((total_bytes as f64) * settings.survivable_fraction) as u64;
+        let basis_points: u64 = match platform {
+            PlatformProfile::Instagram | PlatformProfile::Custom { .. } => 4000,
+            PlatformProfile::Twitter => 3000,
+            PlatformProfile::WhatsApp | PlatformProfile::Imgur => 4500,
+            PlatformProfile::Telegram => 7000,
+        };
+        let survivable = total_bytes.saturating_mul(basis_points).div_euclid(10_000);
         Ok(Capacity {
             bytes: survivable,
             technique: StegoTechnique::LsbImage,
@@ -389,16 +374,26 @@ fn extract_green_f32(data: &Bytes, width: u32, height: u32) -> Vec<f32> {
         .saturating_mul(4);
     if data.len() >= expected {
         // RGBA8
-        data.chunks_exact(4).map(|ch| ch[1] as f32).collect()
+        data.chunks_exact(4)
+            .filter_map(|ch| match ch {
+                [_, g, _, _] => Some(f32::from(*g)),
+                _ => None,
+            })
+            .collect()
     } else if data.len()
         >= (width as usize)
             .saturating_mul(height as usize)
             .saturating_mul(3)
     {
         // RGB8
-        data.chunks_exact(3).map(|ch| ch[1] as f32).collect()
+        data.chunks_exact(3)
+            .filter_map(|ch| match ch {
+                [_, g, _] => Some(f32::from(*g)),
+                _ => None,
+            })
+            .collect()
     } else {
-        data.iter().map(|&b| b as f32).collect()
+        data.iter().map(|&b| f32::from(b)).collect()
     }
 }
 
@@ -434,7 +429,9 @@ mod tests {
     fn built_in_codebook_parses_without_error() {
         let matcher = CoverProfileMatcherImpl::with_built_in();
         assert!(!matcher.ai_profiles.is_empty());
-        assert_eq!(matcher.ai_profiles[0].model_id, "gemini");
+        let first = matcher.ai_profiles.first();
+        assert!(first.is_some());
+        assert_eq!(first.map(|p| p.model_id.as_str()), Some("gemini"));
     }
 
     #[test]
@@ -470,7 +467,11 @@ mod tests {
             noise_floor_db: -80.0,
             model_id: "test".to_string(),
         });
-        let result = matcher.apply_profile(cover.clone(), &profile).unwrap();
+        let result = matcher.apply_profile(cover.clone(), &profile);
+        assert!(result.is_ok());
+        let Some(result) = result.ok() else {
+            return;
+        };
         assert_eq!(result.data, cover.data);
     }
 
@@ -489,7 +490,11 @@ mod tests {
         let cover = make_cover(CoverMediaKind::PngImage, 4, 4);
         let stego = make_cover(CoverMediaKind::PngImage, 4, 4);
         let original_len = stego.data.len();
-        let result = optimiser.optimise(stego, &cover, -12.0).unwrap();
+        let result = optimiser.optimise(stego, &cover, -12.0);
+        assert!(result.is_ok());
+        let Some(result) = result.ok() else {
+            return;
+        };
         assert_eq!(result.data.len(), original_len);
     }
 
@@ -497,9 +502,11 @@ mod tests {
     fn compression_simulator_survivable_capacity() {
         let sim = CompressionSimulatorImpl;
         let cover = make_cover(CoverMediaKind::PngImage, 32, 32);
-        let cap = sim
-            .survivable_capacity(&cover, &PlatformProfile::Instagram)
-            .unwrap();
+        let cap = sim.survivable_capacity(&cover, &PlatformProfile::Instagram);
+        assert!(cap.is_ok());
+        let Some(cap) = cap.ok() else {
+            return;
+        };
         assert!(cap.bytes > 0);
         assert!(cap.bytes < cover.data.len() as u64);
     }
@@ -517,9 +524,11 @@ mod tests {
                 m
             },
         };
-        let result = sim
-            .simulate(cover.clone(), &PlatformProfile::Twitter)
-            .unwrap();
+        let result = sim.simulate(cover.clone(), &PlatformProfile::Twitter);
+        assert!(result.is_ok());
+        let Some(result) = result.ok() else {
+            return;
+        };
         assert_eq!(result.data, cover.data);
     }
 
@@ -528,6 +537,19 @@ mod tests {
         let t = PlatformSettings::for_platform(&PlatformProfile::Telegram);
         let i = PlatformSettings::for_platform(&PlatformProfile::Twitter);
         assert!(t.jpeg_quality > i.jpeg_quality);
-        assert!(t.survivable_fraction > i.survivable_fraction);
+
+        let sim = CompressionSimulatorImpl;
+        let cover = make_cover(CoverMediaKind::PngImage, 32, 32);
+        let t_cap = sim.survivable_capacity(&cover, &PlatformProfile::Telegram);
+        let i_cap = sim.survivable_capacity(&cover, &PlatformProfile::Twitter);
+        assert!(t_cap.is_ok());
+        assert!(i_cap.is_ok());
+        let Some(t_cap) = t_cap.ok() else {
+            return;
+        };
+        let Some(i_cap) = i_cap.ok() else {
+            return;
+        };
+        assert!(t_cap.bytes > i_cap.bytes);
     }
 }

--- a/crates/shadowforge/src/adapters/ai_profiles.json
+++ b/crates/shadowforge/src/adapters/ai_profiles.json
@@ -1,0 +1,22 @@
+{
+  "profiles": [
+    {
+      "model_id": "gemini",
+      "channel_weights": [0.85, 1.0, 0.7],
+      "carrier_map": {
+        "1024x1024": [
+          { "freq": [9, 9], "phase": 0.0, "coherence": 1.0 },
+          { "freq": [5, 5], "phase": 0.0, "coherence": 1.0 },
+          { "freq": [10, 11], "phase": 0.0, "coherence": 1.0 },
+          { "freq": [13, 6], "phase": 0.0, "coherence": 0.82 }
+        ],
+        "1536x2816": [
+          { "freq": [768, 704], "phase": 0.0, "coherence": 0.9955 },
+          { "freq": [672, 1056], "phase": 0.0, "coherence": 0.9746 },
+          { "freq": [480, 1408], "phase": 0.0, "coherence": 0.9655 },
+          { "freq": [384, 1408], "phase": 0.0, "coherence": 0.9586 }
+        ]
+      }
+    }
+  ]
+}

--- a/crates/shadowforge/src/adapters/analysis.rs
+++ b/crates/shadowforge/src/adapters/analysis.rs
@@ -50,6 +50,7 @@ impl CapacityAnalyser for CapacityAnalyserImpl {
             chi_square_score: chi_sq,
             detectability_risk: risk,
             recommended_max_payload_bytes: recommended,
+            spectral_score: None,
         })
     }
 }

--- a/crates/shadowforge/src/adapters/corpus.rs
+++ b/crates/shadowforge/src/adapters/corpus.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use crate::domain::corpus;
 use crate::domain::errors::CorpusError;
 use crate::domain::ports::CorpusIndex;
-use crate::domain::types::{CorpusEntry, CoverMediaKind, Payload, StegoTechnique};
+use crate::domain::types::{CorpusEntry, CoverMediaKind, Payload, SpectralKey, StegoTechnique};
 
 /// In-memory corpus index backed by a `HashMap<file_hash, CorpusEntry>`.
 ///
@@ -20,6 +20,8 @@ use crate::domain::types::{CorpusEntry, CoverMediaKind, Payload, StegoTechnique}
 /// and `build_index`.
 pub struct CorpusIndexImpl {
     entries: RefCell<HashMap<[u8; 32], CorpusEntry>>,
+    /// Spectral key → file hashes for model-aware search.
+    spectral_index: RefCell<HashMap<SpectralKey, Vec<[u8; 32]>>>,
 }
 
 impl CorpusIndexImpl {
@@ -28,6 +30,7 @@ impl CorpusIndexImpl {
     pub fn new() -> Self {
         Self {
             entries: RefCell::new(HashMap::new()),
+            spectral_index: RefCell::new(HashMap::new()),
         }
     }
 
@@ -119,9 +122,12 @@ impl CorpusIndex for CorpusIndexImpl {
             path: path.display().to_string(),
             cover_kind,
             precomputed_bit_pattern: bit_pattern,
+            spectral_key: None,
         };
 
         self.entries.borrow_mut().insert(file_hash, entry.clone());
+        // Spectral key not populated during base indexing (no image decode here).
+        // Callers that have spectral info may insert entries via `add_entry_with_key`.
         Ok(entry)
     }
 
@@ -151,6 +157,74 @@ impl CorpusIndex for CorpusIndexImpl {
         }
 
         Ok(count)
+    }
+
+    fn search_for_model(
+        &self,
+        payload: &Payload,
+        model_id: &str,
+        resolution: (u32, u32),
+        max_results: usize,
+    ) -> Result<Vec<CorpusEntry>, CorpusError> {
+        let key = SpectralKey {
+            model_id: model_id.to_string(),
+            resolution,
+        };
+        let spectral_index = self.spectral_index.borrow();
+        let hashes = spectral_index.get(&key).map_or(&[][..], Vec::as_slice);
+        if hashes.is_empty() {
+            return Err(CorpusError::NoSuitableCover {
+                payload_bytes: payload.len() as u64,
+            });
+        }
+
+        let entries = self.entries.borrow();
+        let payload_pattern = corpus::payload_to_bit_pattern(payload.as_bytes(), None);
+        let mut scored: Vec<(u64, CorpusEntry)> = hashes
+            .iter()
+            .filter_map(|h| entries.get(h))
+            .map(|entry| {
+                let dist = corpus::score_match(&entry.precomputed_bit_pattern, &payload_pattern);
+                (dist, entry.clone())
+            })
+            .collect();
+
+        scored.sort_by_key(|(dist, _)| *dist);
+        scored.truncate(max_results);
+
+        if scored.is_empty() {
+            return Err(CorpusError::NoSuitableCover {
+                payload_bytes: payload.len() as u64,
+            });
+        }
+
+        Ok(scored.into_iter().map(|(_, e)| e).collect())
+    }
+
+    fn model_stats(&self) -> Vec<(SpectralKey, usize)> {
+        let spectral_index = self.spectral_index.borrow();
+        let mut stats: Vec<(SpectralKey, usize)> = spectral_index
+            .iter()
+            .map(|(k, v)| (k.clone(), v.len()))
+            .collect();
+        stats.sort_by(|a, b| a.0.model_id.cmp(&b.0.model_id));
+        stats
+    }
+}
+
+impl CorpusIndexImpl {
+    /// Insert a pre-built [`CorpusEntry`] that already carries a
+    /// [`SpectralKey`].  Used by higher-level pipelines that have already
+    /// decoded the image and run spectral analysis.
+    pub fn add_entry_with_key(&self, entry: CorpusEntry) {
+        if let Some(ref key) = entry.spectral_key {
+            self.spectral_index
+                .borrow_mut()
+                .entry(key.clone())
+                .or_default()
+                .push(entry.file_hash);
+        }
+        self.entries.borrow_mut().insert(entry.file_hash, entry);
     }
 }
 

--- a/crates/shadowforge/src/adapters/distribution.rs
+++ b/crates/shadowforge/src/adapters/distribution.rs
@@ -3,7 +3,7 @@
 
 use crate::domain::distribution::{assign_many_to_many, assign_one_to_many, validate_cover_count};
 use crate::domain::errors::DistributionError;
-use crate::domain::ports::{Distributor, EmbedTechnique};
+use crate::domain::ports::{Distributor, EmbedTechnique, ErrorCorrector};
 use crate::domain::types::{CoverMedia, DistributionPattern, EmbeddingProfile, Payload};
 
 /// Concrete [`Distributor`] implementation.
@@ -171,9 +171,9 @@ fn distribute_one_to_many(
     parity_shards: u8,
     hmac_key: &[u8],
 ) -> Result<Vec<CoverMedia>, DistributionError> {
-    use crate::domain::correction::encode_shards;
-
-    let shards = encode_shards(payload.as_bytes(), data_shards, parity_shards, hmac_key)
+    let corrector = crate::adapters::correction::RsErrorCorrector::new(hmac_key.to_vec());
+    let shards = corrector
+        .encode(payload.as_bytes(), data_shards, parity_shards)
         .map_err(|source| DistributionError::CorrectionFailed { source })?;
 
     let assignments = assign_one_to_many(shards.len(), covers.len());

--- a/crates/shadowforge/src/adapters/mod.rs
+++ b/crates/shadowforge/src/adapters/mod.rs
@@ -1,5 +1,6 @@
 //! Infrastructure adapters implementing domain port traits.
 
+pub mod adaptive;
 pub mod analysis;
 pub mod archive;
 pub mod canary;

--- a/crates/shadowforge/src/adapters/reconstruction.rs
+++ b/crates/shadowforge/src/adapters/reconstruction.rs
@@ -1,9 +1,8 @@
 //! Adapter implementing the [`Reconstructor`] port for K-of-N shard
 //! reassembly with full verification chain.
 
-use crate::domain::correction::decode_shards;
 use crate::domain::errors::ReconstructionError;
-use crate::domain::ports::{ExtractTechnique, Reconstructor};
+use crate::domain::ports::{ErrorCorrector, ExtractTechnique, Reconstructor};
 use crate::domain::reconstruction::{
     arrange_shards, count_present, deserialize_shard, validate_shard_count,
 };
@@ -86,26 +85,30 @@ impl Reconstructor for ReconstructorImpl {
         // Step 3: Validate minimum count
         validate_shard_count(present, usize::from(self.data_shards))?;
 
-        // Step 4: RS-decode
-        let recovered = decode_shards(
-            &slots,
-            self.data_shards,
-            self.parity_shards,
-            &self.hmac_key,
-            self.original_len,
-        )
-        .map_err(|source| ReconstructionError::CorrectionFailed { source })?;
+        // Step 4: RS-decode via the ErrorCorrector port.
+        let corrector = crate::adapters::correction::RsErrorCorrector::new(self.hmac_key.clone());
+        let recovered = corrector
+            .decode(&slots, self.data_shards, self.parity_shards)
+            .map_err(|source| ReconstructionError::CorrectionFailed { source })?;
 
-        Ok(Payload::from_bytes(recovered.to_vec()))
+        let payload_bytes = if self.original_len > 0 {
+            recovered
+                .get(..self.original_len)
+                .map_or_else(|| recovered.to_vec(), ToOwned::to_owned)
+        } else {
+            recovered.to_vec()
+        };
+
+        Ok(Payload::from_bytes(payload_bytes))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::correction::encode_shards;
     use crate::domain::errors::StegoError;
     use crate::domain::ports::EmbedTechnique;
+    use crate::domain::ports::ErrorCorrector;
     use crate::domain::reconstruction::serialize_shard;
     use crate::domain::types::{Capacity, CoverMedia, CoverMediaKind, StegoTechnique};
     use bytes::Bytes;
@@ -188,7 +191,8 @@ mod tests {
         hmac_key: &[u8],
         cover_size: usize,
     ) -> Result<Vec<CoverMedia>, Box<dyn std::error::Error>> {
-        let shards = encode_shards(payload, data_shards, parity_shards, hmac_key)?;
+        let corrector = crate::adapters::correction::RsErrorCorrector::new(hmac_key.to_vec());
+        let shards = corrector.encode(payload, data_shards, parity_shards)?;
         let embedder = MockEmbedder;
         let covers = shards
             .iter()

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -15,10 +15,10 @@ use crate::domain::errors::{
     ScrubberError, StegoError, TimeLockError,
 };
 use crate::domain::ports::{
-    AmnesiaPipeline, ArchiveHandler, CanaryService as CanaryServicePort, CapacityAnalyser,
-    DeadDropEncoder, DeniableEmbedder, Distributor, EmbedTechnique, Encryptor, ExtractTechnique,
-    ForensicWatermarker, PanicWiper, Reconstructor, Signer, StyloScrubber,
-    TimeLockService as TimeLockServicePort,
+    AdaptiveOptimiser, AmnesiaPipeline, ArchiveHandler, CanaryService as CanaryServicePort,
+    CapacityAnalyser, CompressionSimulator, CoverProfileMatcher, DeadDropEncoder, DeniableEmbedder,
+    Distributor, EmbedTechnique, Encryptor, ExtractTechnique, ForensicWatermarker, PanicWiper,
+    Reconstructor, Signer, StyloScrubber, TimeLockService as TimeLockServicePort,
 };
 use crate::domain::types::{
     AnalysisReport, ArchiveFormat, CanaryShard, CoverMedia, DeniableKeySet, DeniablePayloadPair,
@@ -165,6 +165,16 @@ impl KeyGenService {
 
 // ─── DistributeService ────────────────────────────────────────────────────────
 
+/// Dependencies for profile-specific hardening during distribution.
+pub struct AdaptiveProfileDeps<'a> {
+    /// Cover profile matcher dependency.
+    pub matcher: &'a dyn CoverProfileMatcher,
+    /// Adaptive optimiser dependency.
+    pub optimiser: &'a dyn AdaptiveOptimiser,
+    /// Compression simulator dependency.
+    pub compressor: &'a dyn CompressionSimulator,
+}
+
 /// Distribute a payload across multiple covers.
 pub struct DistributeService;
 
@@ -181,6 +191,68 @@ impl DistributeService {
         embedder: &dyn EmbedTechnique,
     ) -> Result<Vec<CoverMedia>, AppError> {
         Ok(distributor.distribute(payload, profile, covers, embedder)?)
+    }
+
+    /// Distribute and apply profile-specific adaptive hardening.
+    ///
+    /// For `Adaptive`, each output cover is optimised against its source cover.
+    /// For `CompressionSurvivable`, each output cover is passed through platform
+    /// recompression simulation.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Distribution`] for distribution failures and
+    /// [`AppError::Adaptive`] for adaptive/profile hardening failures.
+    pub fn distribute_with_profile_hardening(
+        payload: &Payload,
+        covers: Vec<CoverMedia>,
+        profile: &EmbeddingProfile,
+        distributor: &dyn Distributor,
+        embedder: &dyn EmbedTechnique,
+        deps: &AdaptiveProfileDeps<'_>,
+    ) -> Result<Vec<CoverMedia>, AppError> {
+        let prepared_covers: Vec<CoverMedia> = covers
+            .into_iter()
+            .map(|cover| {
+                if let Some(matched) = deps.matcher.profile_for(&cover) {
+                    deps.matcher.apply_profile(cover, &matched)
+                } else {
+                    Ok(cover)
+                }
+            })
+            .collect::<Result<_, _>>()?;
+
+        let original_covers = prepared_covers.clone();
+        let distributed = distributor.distribute(payload, profile, prepared_covers, embedder)?;
+
+        if distributed.len() != original_covers.len() {
+            return Err(AppError::Adaptive(AdaptiveError::ProfileMatchFailed {
+                reason: format!(
+                    "distributed cover count mismatch: got {}, expected {}",
+                    distributed.len(),
+                    original_covers.len()
+                ),
+            }));
+        }
+
+        match profile {
+            EmbeddingProfile::Standard | EmbeddingProfile::CorpusBased => Ok(distributed),
+            EmbeddingProfile::Adaptive {
+                max_detectability_db,
+            } => distributed
+                .into_iter()
+                .zip(original_covers.iter())
+                .map(|(stego, original)| {
+                    deps.optimiser
+                        .optimise(stego, original, *max_detectability_db)
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(AppError::from),
+            EmbeddingProfile::CompressionSurvivable { platform } => distributed
+                .into_iter()
+                .map(|stego| deps.compressor.simulate(stego, platform))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(AppError::from),
+        }
     }
 }
 
@@ -467,6 +539,8 @@ mod tests {
     use super::*;
     use crate::domain::types::{Capacity, CoverMediaKind, Shard};
     use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -756,6 +830,151 @@ mod tests {
         let result =
             DistributeService::distribute(&payload, covers, &profile, &distributor, &embedder)?;
         assert_eq!(result.len(), 2);
+        Ok(())
+    }
+
+    struct MockCoverProfileMatcher {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl CoverProfileMatcher for MockCoverProfileMatcher {
+        fn profile_for(&self, _cover: &CoverMedia) -> Option<crate::domain::ports::CoverProfile> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            None
+        }
+
+        fn apply_profile(
+            &self,
+            cover: CoverMedia,
+            _profile: &crate::domain::ports::CoverProfile,
+        ) -> Result<CoverMedia, AdaptiveError> {
+            Ok(cover)
+        }
+    }
+
+    struct MockAdaptiveOptimiser {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl AdaptiveOptimiser for MockAdaptiveOptimiser {
+        fn optimise(
+            &self,
+            stego: CoverMedia,
+            _original: &CoverMedia,
+            _target_db: f64,
+        ) -> Result<CoverMedia, AdaptiveError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(stego)
+        }
+    }
+
+    struct MockCompressionSimulator {
+        simulate_calls: Arc<AtomicUsize>,
+    }
+
+    impl CompressionSimulator for MockCompressionSimulator {
+        fn simulate(
+            &self,
+            cover: CoverMedia,
+            _platform: &PlatformProfile,
+        ) -> Result<CoverMedia, AdaptiveError> {
+            self.simulate_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(cover)
+        }
+
+        fn survivable_capacity(
+            &self,
+            cover: &CoverMedia,
+            _platform: &PlatformProfile,
+        ) -> Result<Capacity, AdaptiveError> {
+            Ok(Capacity {
+                bytes: cover.data.len() as u64,
+                technique: StegoTechnique::LsbImage,
+            })
+        }
+    }
+
+    #[test]
+    fn distribute_with_profile_hardening_uses_optimiser_for_adaptive() -> TestResult {
+        let payload = Payload::from_bytes(b"payload".to_vec());
+        let covers = vec![make_cover(64), make_cover(64)];
+        let profile = EmbeddingProfile::Adaptive {
+            max_detectability_db: -12.0,
+        };
+        let distributor = MockDistributor;
+        let embedder = MockEmbedder;
+        let matcher_calls = Arc::new(AtomicUsize::new(0));
+        let optimiser_calls = Arc::new(AtomicUsize::new(0));
+        let simulator_calls = Arc::new(AtomicUsize::new(0));
+        let matcher = MockCoverProfileMatcher {
+            calls: Arc::clone(&matcher_calls),
+        };
+        let optimiser = MockAdaptiveOptimiser {
+            calls: Arc::clone(&optimiser_calls),
+        };
+        let compressor = MockCompressionSimulator {
+            simulate_calls: Arc::clone(&simulator_calls),
+        };
+
+        let result = DistributeService::distribute_with_profile_hardening(
+            &payload,
+            covers,
+            &profile,
+            &distributor,
+            &embedder,
+            &AdaptiveProfileDeps {
+                matcher: &matcher,
+                optimiser: &optimiser,
+                compressor: &compressor,
+            },
+        )?;
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(matcher_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(optimiser_calls.load(Ordering::Relaxed), 2);
+        assert_eq!(simulator_calls.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn distribute_with_profile_hardening_uses_simulator_for_survivable() -> TestResult {
+        let payload = Payload::from_bytes(b"payload".to_vec());
+        let covers = vec![make_cover(64), make_cover(64), make_cover(64)];
+        let profile = EmbeddingProfile::CompressionSurvivable {
+            platform: PlatformProfile::Instagram,
+        };
+        let distributor = MockDistributor;
+        let embedder = MockEmbedder;
+        let matcher_calls = Arc::new(AtomicUsize::new(0));
+        let optimiser_calls = Arc::new(AtomicUsize::new(0));
+        let simulator_calls = Arc::new(AtomicUsize::new(0));
+        let matcher = MockCoverProfileMatcher {
+            calls: Arc::clone(&matcher_calls),
+        };
+        let optimiser = MockAdaptiveOptimiser {
+            calls: Arc::clone(&optimiser_calls),
+        };
+        let compressor = MockCompressionSimulator {
+            simulate_calls: Arc::clone(&simulator_calls),
+        };
+
+        let result = DistributeService::distribute_with_profile_hardening(
+            &payload,
+            covers,
+            &profile,
+            &distributor,
+            &embedder,
+            &AdaptiveProfileDeps {
+                matcher: &matcher,
+                optimiser: &optimiser,
+                compressor: &compressor,
+            },
+        )?;
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(matcher_calls.load(Ordering::Relaxed), 3);
+        assert_eq!(optimiser_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(simulator_calls.load(Ordering::Relaxed), 3);
         Ok(())
     }
 

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -300,7 +300,7 @@ impl DistributeService {
                 let original_covers = original_covers_opt.unwrap_or_default();
                 distributed
                     .into_iter()
-                    .zip(original_covers.into_iter())
+                    .zip(original_covers)
                     .map(|(stego, original)| {
                         deps.optimiser
                             .optimise(stego, &original, *max_detectability_db)

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -18,7 +18,7 @@ use crate::domain::ports::{
     AdaptiveOptimiser, AmnesiaPipeline, ArchiveHandler, CanaryService as CanaryServicePort,
     CapacityAnalyser, CompressionSimulator, CoverProfileMatcher, DeadDropEncoder, DeniableEmbedder,
     Distributor, EmbedTechnique, Encryptor, ExtractTechnique, ForensicWatermarker, PanicWiper,
-    Reconstructor, Signer, StyloScrubber, TimeLockService as TimeLockServicePort,
+    Reconstructor, Signer, StyloScrubber, SymmetricCipher, TimeLockService as TimeLockServicePort,
 };
 use crate::domain::types::{
     AnalysisReport, ArchiveFormat, CanaryShard, CoverMedia, DeniableKeySet, DeniablePayloadPair,
@@ -160,6 +160,39 @@ impl KeyGenService {
         signature: &Signature,
     ) -> Result<bool, AppError> {
         Ok(signer.verify(public_key, message, signature)?)
+    }
+}
+
+// ─── CipherService ───────────────────────────────────────────────────────────
+
+/// AES-256-GCM encrypt / decrypt orchestrator.
+pub struct CipherService;
+
+impl CipherService {
+    /// Encrypt `plaintext` with `key` and `nonce`.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Crypto`] on encryption failure.
+    pub fn encrypt(
+        cipher: &dyn SymmetricCipher,
+        key: &[u8],
+        nonce: &[u8],
+        plaintext: &[u8],
+    ) -> Result<Bytes, AppError> {
+        Ok(cipher.encrypt(key, nonce, plaintext)?)
+    }
+
+    /// Decrypt and authenticate `ciphertext` with `key` and `nonce`.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Crypto`] on decryption or authentication failure.
+    pub fn decrypt(
+        cipher: &dyn SymmetricCipher,
+        key: &[u8],
+        nonce: &[u8],
+        ciphertext: &[u8],
+    ) -> Result<Bytes, AppError> {
+        Ok(cipher.decrypt(key, nonce, ciphertext)?)
     }
 }
 
@@ -1394,5 +1427,34 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("crypto"));
         assert!(msg.contains("oops"));
+    }
+
+    // ─── CipherService ────────────────────────────────────────────────────
+
+    #[test]
+    fn cipher_service_encrypt_decrypt_roundtrip() -> TestResult {
+        use crate::adapters::crypto::Aes256GcmCipher;
+        let cipher = Aes256GcmCipher;
+        let key = vec![0u8; 32];
+        let nonce = vec![1u8; 12];
+        let plaintext = b"secret cipher payload";
+        let ct = CipherService::encrypt(&cipher, &key, &nonce, plaintext)?;
+        let pt = CipherService::decrypt(&cipher, &key, &nonce, &ct)?;
+        assert_eq!(pt.as_ref(), plaintext);
+        Ok(())
+    }
+
+    #[test]
+    fn cipher_service_decrypt_fails_on_tamper() -> TestResult {
+        use crate::adapters::crypto::Aes256GcmCipher;
+        let cipher = Aes256GcmCipher;
+        let key = vec![0u8; 32];
+        let nonce = vec![1u8; 12];
+        let plaintext = b"secret cipher payload";
+        let mut ct = CipherService::encrypt(&cipher, &key, &nonce, plaintext)?.to_vec();
+        *ct.get_mut(0).ok_or("empty ciphertext")? ^= 0xFF;
+        let result = CipherService::decrypt(&cipher, &key, &nonce, &ct);
+        assert!(result.is_err(), "tampered ciphertext must fail decryption");
+        Ok(())
     }
 }

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -1569,7 +1569,10 @@ mod tests {
         let payload = Payload::from_bytes(bytes::Bytes::from_static(b"hello"));
         let results = CorpusService::search(&idx, &payload, StegoTechnique::LsbImage, 5)?;
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].path, entry.path);
+        assert_eq!(
+            results.first().map(|it| it.path.as_str()),
+            Some(entry.path.as_str())
+        );
         Ok(())
     }
 
@@ -1580,7 +1583,10 @@ mod tests {
         let payload = Payload::from_bytes(bytes::Bytes::from_static(b"hello"));
         let results = CorpusService::search_for_model(&idx, &payload, "gemini", (1920, 1080), 3)?;
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].path, entry.path);
+        assert_eq!(
+            results.first().map(|it| it.path.as_str()),
+            Some(entry.path.as_str())
+        );
         Ok(())
     }
 
@@ -1589,8 +1595,11 @@ mod tests {
         let idx = MockCorpusIndex::new(7, vec![]);
         let stats = CorpusService::model_stats(&idx);
         assert_eq!(stats.len(), 1);
-        assert_eq!(stats[0].0.model_id, "test-model");
-        assert_eq!(stats[0].1, 7);
+        assert_eq!(
+            stats.first().map(|(k, _)| k.model_id.as_str()),
+            Some("test-model")
+        );
+        assert_eq!(stats.first().map(|(_, c)| *c), Some(7));
     }
 
     // ─── CipherService ────────────────────────────────────────────────────

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -259,43 +259,58 @@ impl DistributeService {
         embedder: &dyn EmbedTechnique,
         deps: &AdaptiveProfileDeps<'_>,
     ) -> Result<Vec<CoverMedia>, AppError> {
-        let prepared_covers: Vec<CoverMedia> = covers
-            .into_iter()
-            .map(|cover| {
-                if let Some(matched) = deps.matcher.profile_for(&cover) {
-                    deps.matcher.apply_profile(cover, &matched)
-                } else {
-                    Ok(cover)
-                }
-            })
-            .collect::<Result<_, _>>()?;
+        // Profile matching (FFT on each cover) is only needed for
+        // Adaptive and CompressionSurvivable profiles; skip it for the
+        // cheaper Standard / CorpusBased paths.
+        let prepared_covers: Vec<CoverMedia> = match profile {
+            EmbeddingProfile::Standard | EmbeddingProfile::CorpusBased => covers,
+            _ => covers
+                .into_iter()
+                .map(|cover| {
+                    if let Some(matched) = deps.matcher.profile_for(&cover) {
+                        deps.matcher.apply_profile(cover, &matched)
+                    } else {
+                        Ok(cover)
+                    }
+                })
+                .collect::<Result<_, _>>()?,
+        };
 
-        let original_covers = prepared_covers.clone();
+        let original_cover_count = prepared_covers.len();
+        // Clone originals only for the Adaptive branch, which needs to pair each
+        // output cover against its source for detectability scoring.
+        let original_covers_opt: Option<Vec<CoverMedia>> = matches!(
+            profile,
+            EmbeddingProfile::Adaptive { .. }
+        )
+        .then(|| prepared_covers.clone());
         let distributed = distributor.distribute(payload, profile, prepared_covers, embedder)?;
 
-        if distributed.len() != original_covers.len() {
-            return Err(AppError::Adaptive(AdaptiveError::ProfileMatchFailed {
-                reason: format!(
-                    "distributed cover count mismatch: got {}, expected {}",
-                    distributed.len(),
-                    original_covers.len()
-                ),
-            }));
+        if distributed.len() != original_cover_count {
+            return Err(AppError::Adaptive(
+                AdaptiveError::DistributionCountMismatch {
+                    got: distributed.len(),
+                    expected: original_cover_count,
+                },
+            ));
         }
 
         match profile {
             EmbeddingProfile::Standard | EmbeddingProfile::CorpusBased => Ok(distributed),
             EmbeddingProfile::Adaptive {
                 max_detectability_db,
-            } => distributed
-                .into_iter()
-                .zip(original_covers.iter())
-                .map(|(stego, original)| {
-                    deps.optimiser
-                        .optimise(stego, original, *max_detectability_db)
-                })
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(AppError::from),
+            } => {
+                let original_covers = original_covers_opt.unwrap_or_default();
+                distributed
+                    .into_iter()
+                    .zip(original_covers.into_iter())
+                    .map(|(stego, original)| {
+                        deps.optimiser
+                            .optimise(stego, &original, *max_detectability_db)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(AppError::from)
+            }
             EmbeddingProfile::CompressionSurvivable { platform } => distributed
                 .into_iter()
                 .map(|stego| deps.compressor.simulate(stego, platform))

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -16,14 +16,16 @@ use crate::domain::errors::{
 };
 use crate::domain::ports::{
     AdaptiveOptimiser, AmnesiaPipeline, ArchiveHandler, CanaryService as CanaryServicePort,
-    CapacityAnalyser, CompressionSimulator, CoverProfileMatcher, DeadDropEncoder, DeniableEmbedder,
-    Distributor, EmbedTechnique, Encryptor, ExtractTechnique, ForensicWatermarker, PanicWiper,
-    Reconstructor, Signer, StyloScrubber, SymmetricCipher, TimeLockService as TimeLockServicePort,
+    CapacityAnalyser, CompressionSimulator, CorpusIndex, CoverProfileMatcher, DeadDropEncoder,
+    DeniableEmbedder, Distributor, EmbedTechnique, Encryptor, ExtractTechnique,
+    ForensicWatermarker, PanicWiper, Reconstructor, Signer, StyloScrubber, SymmetricCipher,
+    TimeLockService as TimeLockServicePort,
 };
 use crate::domain::types::{
-    AnalysisReport, ArchiveFormat, CanaryShard, CoverMedia, DeniableKeySet, DeniablePayloadPair,
-    EmbeddingProfile, KeyPair, PanicWipeConfig, Payload, PlatformProfile, Signature,
-    StegoTechnique, StyloProfile, TimeLockPuzzle, WatermarkReceipt, WatermarkTripwireTag,
+    AnalysisReport, ArchiveFormat, CanaryShard, CorpusEntry, CoverMedia, DeniableKeySet,
+    DeniablePayloadPair, EmbeddingProfile, KeyPair, PanicWipeConfig, Payload, PlatformProfile,
+    Signature, SpectralKey, StegoTechnique, StyloProfile, TimeLockPuzzle, WatermarkReceipt,
+    WatermarkTripwireTag,
 };
 
 // ─── AppError ─────────────────────────────────────────────────────────────────
@@ -562,6 +564,56 @@ impl PanicWipeService {
     /// Returns [`AppError::Opsec`] on failure.
     pub fn wipe(config: &PanicWipeConfig, wiper: &dyn PanicWiper) -> Result<(), AppError> {
         Ok(wiper.wipe(config)?)
+    }
+}
+
+// ─── CorpusService ───────────────────────────────────────────────────────────
+
+/// Corpus index and cover-selection orchestrator.
+pub struct CorpusService;
+
+impl CorpusService {
+    /// Build the corpus index from a directory tree.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Corpus`] on failure.
+    pub fn build_index(
+        index: &dyn CorpusIndex,
+        corpus_dir: &std::path::Path,
+    ) -> Result<usize, AppError> {
+        Ok(index.build_index(corpus_dir)?)
+    }
+
+    /// Search the index for covers that best encode `payload` using `technique`.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Corpus`] on failure.
+    pub fn search(
+        index: &dyn CorpusIndex,
+        payload: &Payload,
+        technique: StegoTechnique,
+        max_results: usize,
+    ) -> Result<Vec<CorpusEntry>, AppError> {
+        Ok(index.search(payload, technique, max_results)?)
+    }
+
+    /// Search the index restricted to a specific camera model and resolution.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Corpus`] on failure.
+    pub fn search_for_model(
+        index: &dyn CorpusIndex,
+        payload: &Payload,
+        model_id: &str,
+        resolution: (u32, u32),
+        max_results: usize,
+    ) -> Result<Vec<CorpusEntry>, AppError> {
+        Ok(index.search_for_model(payload, model_id, resolution, max_results)?)
+    }
+
+    /// Return per-model/resolution entry counts from the index.
+    pub fn model_stats(index: &dyn CorpusIndex) -> Vec<(SpectralKey, usize)> {
+        index.model_stats()
     }
 }
 
@@ -1427,6 +1479,118 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("crypto"));
         assert!(msg.contains("oops"));
+    }
+
+    // ─── CorpusService ────────────────────────────────────────────────────
+
+    struct MockCorpusIndex {
+        build_count: usize,
+        search_entries: Vec<CorpusEntry>,
+    }
+
+    impl MockCorpusIndex {
+        fn new(build_count: usize, search_entries: Vec<CorpusEntry>) -> Self {
+            Self {
+                build_count,
+                search_entries,
+            }
+        }
+    }
+
+    impl crate::domain::ports::CorpusIndex for MockCorpusIndex {
+        fn build_index(
+            &self,
+            _dir: &std::path::Path,
+        ) -> Result<usize, crate::domain::errors::CorpusError> {
+            Ok(self.build_count)
+        }
+        fn add_to_index(
+            &self,
+            path: &std::path::Path,
+        ) -> Result<CorpusEntry, crate::domain::errors::CorpusError> {
+            Ok(CorpusEntry {
+                file_hash: [0u8; 32],
+                path: path.to_string_lossy().into_owned(),
+                cover_kind: CoverMediaKind::PngImage,
+                precomputed_bit_pattern: bytes::Bytes::new(),
+                spectral_key: None,
+            })
+        }
+        fn search(
+            &self,
+            _payload: &Payload,
+            _technique: StegoTechnique,
+            _max: usize,
+        ) -> Result<Vec<CorpusEntry>, crate::domain::errors::CorpusError> {
+            Ok(self.search_entries.clone())
+        }
+        fn search_for_model(
+            &self,
+            _payload: &Payload,
+            _model_id: &str,
+            _res: (u32, u32),
+            _max: usize,
+        ) -> Result<Vec<CorpusEntry>, crate::domain::errors::CorpusError> {
+            Ok(self.search_entries.clone())
+        }
+        fn model_stats(&self) -> Vec<(SpectralKey, usize)> {
+            vec![(
+                SpectralKey {
+                    model_id: "test-model".into(),
+                    resolution: (1920, 1080),
+                },
+                self.build_count,
+            )]
+        }
+    }
+
+    fn make_corpus_entry(path: &str) -> CorpusEntry {
+        CorpusEntry {
+            file_hash: [0u8; 32],
+            path: path.to_owned(),
+            cover_kind: CoverMediaKind::PngImage,
+            precomputed_bit_pattern: bytes::Bytes::new(),
+            spectral_key: None,
+        }
+    }
+
+    #[test]
+    fn corpus_service_build_index() -> TestResult {
+        let idx = MockCorpusIndex::new(42, vec![]);
+        let count = CorpusService::build_index(&idx, std::path::Path::new("/some/dir"))?;
+        assert_eq!(count, 42);
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_service_search() -> TestResult {
+        let entry = make_corpus_entry("covers/img001.png");
+        let idx = MockCorpusIndex::new(1, vec![entry.clone()]);
+        let payload = Payload::from_bytes(bytes::Bytes::from_static(b"hello"));
+        let results = CorpusService::search(&idx, &payload, StegoTechnique::LsbImage, 5)?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, entry.path);
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_service_search_for_model() -> TestResult {
+        let entry = make_corpus_entry("covers/gemini001.png");
+        let idx = MockCorpusIndex::new(1, vec![entry.clone()]);
+        let payload = Payload::from_bytes(bytes::Bytes::from_static(b"hello"));
+        let results = CorpusService::search_for_model(&idx, &payload, "gemini", (1920, 1080), 3)?;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, entry.path);
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_service_model_stats() {
+        let idx = MockCorpusIndex::new(7, vec![]);
+        let stats = CorpusService::model_stats(&idx);
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].0.model_id, "test-model");
+        assert_eq!(stats[0].1, 7);
     }
 
     // ─── CipherService ────────────────────────────────────────────────────

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -18,14 +18,14 @@ use crate::domain::ports::{
     AdaptiveOptimiser, AmnesiaPipeline, ArchiveHandler, CanaryService as CanaryServicePort,
     CapacityAnalyser, CompressionSimulator, CorpusIndex, CoverProfileMatcher, DeadDropEncoder,
     DeniableEmbedder, Distributor, EmbedTechnique, Encryptor, ExtractTechnique,
-    ForensicWatermarker, PanicWiper, Reconstructor, Signer, StyloScrubber, SymmetricCipher,
-    TimeLockService as TimeLockServicePort,
+    ForensicWatermarker, GeographicDistributor, PanicWiper, Reconstructor, Signer, StyloScrubber,
+    SymmetricCipher, TimeLockService as TimeLockServicePort,
 };
 use crate::domain::types::{
     AnalysisReport, ArchiveFormat, CanaryShard, CorpusEntry, CoverMedia, DeniableKeySet,
-    DeniablePayloadPair, EmbeddingProfile, KeyPair, PanicWipeConfig, Payload, PlatformProfile,
-    Signature, SpectralKey, StegoTechnique, StyloProfile, TimeLockPuzzle, WatermarkReceipt,
-    WatermarkTripwireTag,
+    DeniablePayloadPair, EmbeddingProfile, GeographicManifest, KeyPair, PanicWipeConfig, Payload,
+    PlatformProfile, Signature, SpectralKey, StegoTechnique, StyloProfile, TimeLockPuzzle,
+    WatermarkReceipt, WatermarkTripwireTag,
 };
 
 // ─── AppError ─────────────────────────────────────────────────────────────────
@@ -226,6 +226,20 @@ impl DistributeService {
         embedder: &dyn EmbedTechnique,
     ) -> Result<Vec<CoverMedia>, AppError> {
         Ok(distributor.distribute(payload, profile, covers, embedder)?)
+    }
+
+    /// Distribute `payload` across `covers` with a geographic manifest.
+    ///
+    /// # Errors
+    /// Returns [`AppError::Opsec`] on manifest/distribution failures.
+    pub fn distribute_with_geographic_manifest(
+        payload: &Payload,
+        covers: Vec<CoverMedia>,
+        manifest: &GeographicManifest,
+        embedder: &dyn EmbedTechnique,
+        distributor: &dyn GeographicDistributor,
+    ) -> Result<Vec<CoverMedia>, AppError> {
+        Ok(distributor.distribute_with_manifest(payload, covers, manifest, embedder)?)
     }
 
     /// Distribute and apply profile-specific adaptive hardening.
@@ -622,7 +636,7 @@ impl CorpusService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::types::{Capacity, CoverMediaKind, Shard};
+    use crate::domain::types::{Capacity, CoverMediaKind, GeoShardEntry, Shard};
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -952,6 +966,20 @@ mod tests {
         }
     }
 
+    struct MockGeographicDistributor;
+
+    impl GeographicDistributor for MockGeographicDistributor {
+        fn distribute_with_manifest(
+            &self,
+            _payload: &Payload,
+            covers: Vec<CoverMedia>,
+            _manifest: &GeographicManifest,
+            _embedder: &dyn EmbedTechnique,
+        ) -> Result<Vec<CoverMedia>, OpsecError> {
+            Ok(covers)
+        }
+    }
+
     #[test]
     fn distribute_service_returns_covers() -> TestResult {
         let payload = Payload::from_bytes(b"payload".to_vec());
@@ -961,6 +989,32 @@ mod tests {
         let embedder = MockEmbedder;
         let result =
             DistributeService::distribute(&payload, covers, &profile, &distributor, &embedder)?;
+        assert_eq!(result.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn distribute_service_geographic_manifest_returns_covers() -> TestResult {
+        let payload = Payload::from_bytes(b"payload".to_vec());
+        let covers = vec![make_cover(64), make_cover(64)];
+        let manifest = GeographicManifest {
+            shards: vec![GeoShardEntry {
+                shard_index: 0,
+                jurisdiction: "US".to_string(),
+                holder_description: "test holder".to_string(),
+            }],
+            minimum_jurisdictions: 1,
+        };
+        let distributor = MockGeographicDistributor;
+        let embedder = MockEmbedder;
+
+        let result = DistributeService::distribute_with_geographic_manifest(
+            &payload,
+            covers,
+            &manifest,
+            &embedder,
+            &distributor,
+        )?;
         assert_eq!(result.len(), 2);
         Ok(())
     }

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -861,6 +861,34 @@ mod tests {
         }
     }
 
+    struct MockSelectiveSigner;
+
+    impl Signer for MockSelectiveSigner {
+        fn generate_keypair(&self) -> Result<KeyPair, CryptoError> {
+            Ok(KeyPair {
+                public_key: vec![5u8; 32],
+                secret_key: vec![6u8; 32],
+            })
+        }
+
+        fn sign(&self, _secret_key: &[u8], message: &[u8]) -> Result<Signature, CryptoError> {
+            let mut sig = b"sig:".to_vec();
+            sig.extend_from_slice(message);
+            Ok(Signature(Bytes::from(sig)))
+        }
+
+        fn verify(
+            &self,
+            _public_key: &[u8],
+            message: &[u8],
+            signature: &Signature,
+        ) -> Result<bool, CryptoError> {
+            let mut expected = b"sig:".to_vec();
+            expected.extend_from_slice(message);
+            Ok(signature.0.as_ref() == expected.as_slice())
+        }
+    }
+
     #[test]
     fn keygen_generate_keypair() -> TestResult {
         let encryptor = MockEncryptor;
@@ -886,6 +914,25 @@ mod tests {
         assert_eq!(signature.0.len(), 64);
         let valid = KeyGenService::verify(&signer, &[0u8; 32], b"test message", &signature)?;
         assert!(valid);
+        Ok(())
+    }
+
+    #[test]
+    fn keygen_verify_invalid_signature_returns_false() -> TestResult {
+        let signer = MockSelectiveSigner;
+        let invalid_signature = Signature(Bytes::from_static(b"sig:wrong message"));
+        let valid =
+            KeyGenService::verify(&signer, &[0u8; 32], b"test message", &invalid_signature)?;
+        assert!(!valid);
+        Ok(())
+    }
+
+    #[test]
+    fn keygen_verify_tampered_message_returns_false() -> TestResult {
+        let signer = MockSelectiveSigner;
+        let signature = KeyGenService::sign(&signer, &[0u8; 32], b"test message")?;
+        let valid = KeyGenService::verify(&signer, &[0u8; 32], b"tampered message", &signature)?;
+        assert!(!valid);
         Ok(())
     }
 

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -279,11 +279,8 @@ impl DistributeService {
         let original_cover_count = prepared_covers.len();
         // Clone originals only for the Adaptive branch, which needs to pair each
         // output cover against its source for detectability scoring.
-        let original_covers_opt: Option<Vec<CoverMedia>> = matches!(
-            profile,
-            EmbeddingProfile::Adaptive { .. }
-        )
-        .then(|| prepared_covers.clone());
+        let original_covers_opt: Option<Vec<CoverMedia>> =
+            matches!(profile, EmbeddingProfile::Adaptive { .. }).then(|| prepared_covers.clone());
         let distributed = distributor.distribute(payload, profile, prepared_covers, embedder)?;
 
         if distributed.len() != original_cover_count {

--- a/crates/shadowforge/src/domain/adaptive/mod.rs
+++ b/crates/shadowforge/src/domain/adaptive/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! Pure domain logic — no I/O, no file system, no async runtime.
 
+use rand::RngExt as _;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -27,28 +28,28 @@ impl BinMask {
     /// Build a bin-occupancy mask from `profile` at the given resolution.
     ///
     /// - `CoverProfile::Camera` → all-zeros (no protected bins).
-    /// - `CoverProfile::AiGenerator` → marks strong carrier bins (`coherence
-    ///   >= 0.90`).
+    /// - `CoverProfile::AiGenerator` → marks strong carrier bins
+    ///   (`coherence >= 0.90`).
     #[must_use]
     pub fn build(profile: &CoverProfile, width: u32, height: u32) -> Self {
         let len = (width as usize).strict_mul(height as usize);
         let mut occupied = vec![false; len];
 
-        if let CoverProfile::AiGenerator(p) = profile {
-            if let Some(bins) = p.carrier_bins_for(width, height) {
-                for bin in bins.iter().filter(|b| b.is_strong()) {
-                    let (row, col) = bin.freq;
-                    if row < height && col < width {
-                        let idx = (row as usize)
-                            .strict_mul(width as usize)
-                            .strict_add(col as usize);
-                        #[expect(
-                            clippy::indexing_slicing,
-                            reason = "idx < len is guaranteed by the row/col range check above"
-                        )]
-                        {
-                            occupied[idx] = true;
-                        }
+        if let CoverProfile::AiGenerator(p) = profile
+            && let Some(bins) = p.carrier_bins_for(width, height)
+        {
+            for bin in bins.iter().filter(|b| b.is_strong()) {
+                let (row, col) = bin.freq;
+                if row < height && col < width {
+                    let idx = (row as usize)
+                        .strict_mul(width as usize)
+                        .strict_add(col as usize);
+                    #[expect(
+                        clippy::indexing_slicing,
+                        reason = "idx < len is guaranteed by the row/col range check above"
+                    )]
+                    {
+                        occupied[idx] = true;
                     }
                 }
             }
@@ -81,7 +82,7 @@ impl BinMask {
 
     /// Total number of bins in the mask.
     #[must_use]
-    pub fn total_bins(&self) -> usize {
+    pub const fn total_bins(&self) -> usize {
         self.occupied.len()
     }
 }
@@ -99,8 +100,17 @@ pub fn cost_at(bit_position: usize, total_positions: usize, mask: &BinMask) -> f
         return f64::INFINITY;
     }
 
-    let col = (bit_position % mask.width as usize) as u32;
-    let row = (bit_position / mask.width.max(1) as usize) as u32;
+    let Ok(width) = usize::try_from(mask.width.max(1)) else {
+        return f64::INFINITY;
+    };
+    let col_usize = bit_position % width;
+    let row_usize = bit_position / width;
+    let Ok(col) = u32::try_from(col_usize) else {
+        return f64::INFINITY;
+    };
+    let Ok(row) = u32::try_from(row_usize) else {
+        return f64::INFINITY;
+    };
 
     if mask.is_occupied(row, col) {
         return f64::INFINITY;
@@ -109,7 +119,13 @@ pub fn cost_at(bit_position: usize, total_positions: usize, mask: &BinMask) -> f
     // Soft margin: positions near the boundary of occupied regions get a
     // slightly higher cost (up to 2.0).  We use the fractional position
     // within the image as a proxy for proximity to occupied areas.
-    let fraction = bit_position as f64 / total_positions as f64;
+    let bit_position_f = u32::try_from(bit_position)
+        .ok()
+        .map_or_else(|| f64::from(u32::MAX), f64::from);
+    let total_positions_f = u32::try_from(total_positions)
+        .ok()
+        .map_or_else(|| f64::from(u32::MAX), f64::from);
+    let fraction = bit_position_f / total_positions_f;
     1.0 + fraction.min(1.0)
 }
 
@@ -135,27 +151,25 @@ impl Permutation {
     /// Apply the permutation to `data` in-place (cycle-following algorithm).
     pub fn apply(&self, data: &mut [u8]) {
         let n = data.len().min(self.map.len());
-        let mut visited = vec![false; n];
+        let source = match data.get(..n) {
+            Some(slice) => slice.to_vec(),
+            None => return,
+        };
+        let mut dest = source.clone();
 
-        for start in 0..n {
-            if visited[start] || self.map.get(start).copied().unwrap_or(start) == start {
-                visited[start] = true;
+        for (original_position, &new_position) in self.map.iter().take(n).enumerate() {
+            if new_position >= n {
                 continue;
             }
-
-            // Follow the cycle collecting original values.
-            let saved = data[start];
-            let mut current = start;
-            loop {
-                let next = self.map.get(current).copied().unwrap_or(current);
-                visited[current] = true;
-                if next == start {
-                    data[current] = saved;
-                    break;
-                }
-                data[current] = data[next];
-                current = next;
+            if let (Some(dst), Some(&src)) =
+                (dest.get_mut(new_position), source.get(original_position))
+            {
+                *dst = src;
             }
+        }
+
+        if let Some(target) = data.get_mut(..n) {
+            target.copy_from_slice(&dest);
         }
     }
 
@@ -177,7 +191,7 @@ impl Permutation {
         Self { map: inv }
     }
 
-    /// Raw permutation map (original_position → new_position).
+    /// Raw permutation map (`original_position -> new_position`).
     #[must_use]
     pub fn as_slice(&self) -> &[usize] {
         &self.map
@@ -224,8 +238,6 @@ pub fn permutation_search(
         return Permutation::identity(stego_bytes.len());
     }
 
-    use rand::RngExt as _;
-
     let n = stego_bytes.len();
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut best_perm = Permutation::identity(n);
@@ -250,8 +262,10 @@ pub fn permutation_search(
         while idx_b == idx_a {
             idx_b = rng.random_range(0..safe_positions.len());
         }
-        let pos_a = safe_positions[idx_a];
-        let pos_b = safe_positions[idx_b];
+        let (Some(&pos_a), Some(&pos_b)) = (safe_positions.get(idx_a), safe_positions.get(idx_b))
+        else {
+            continue;
+        };
 
         // Tentatively swap in both the map and the data.
         current_map.swap(pos_a, pos_b);
@@ -283,8 +297,6 @@ mod tests {
     use super::*;
     use crate::domain::ports::{AiGenProfile, CarrierBin, CoverProfile};
     use std::collections::HashMap;
-
-    type TestResult = Result<(), Box<dyn std::error::Error>>;
 
     fn gemini_1024_profile() -> CoverProfile {
         let bins = vec![
@@ -408,13 +420,12 @@ mod tests {
     }
 
     #[test]
-    fn permutation_identity_apply_is_noop() -> TestResult {
+    fn permutation_identity_apply_is_noop() {
         let original = vec![1u8, 2, 3, 4];
         let mut data = original.clone();
         let perm = Permutation::identity(4);
         perm.apply(&mut data);
         assert_eq!(data, original);
-        Ok(())
     }
 
     #[test]

--- a/crates/shadowforge/src/domain/adaptive/mod.rs
+++ b/crates/shadowforge/src/domain/adaptive/mod.rs
@@ -7,7 +7,7 @@ use rand::RngExt as _;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use crate::domain::analysis::chi_square_score;
+use crate::domain::analysis::pair_delta_chi_square_score;
 use crate::domain::ports::CoverProfile;
 
 // ─── BinMask ─────────────────────────────────────────────────────────────────
@@ -241,7 +241,9 @@ pub fn permutation_search(
     let n = stego_bytes.len();
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut best_perm = Permutation::identity(n);
-    let mut best_score = chi_square_score(stego_bytes);
+    // Use pair-delta chi-square (order-sensitive) so that swapping bytes
+    // actually changes the score and the hill-climb can make progress.
+    let mut best_score = pair_delta_chi_square_score(stego_bytes);
 
     // Collect safe (non-occupied) positions to limit candidate swaps.
     let safe_positions: Vec<usize> = (0..n)
@@ -271,7 +273,7 @@ pub fn permutation_search(
         current_map.swap(pos_a, pos_b);
         current_data.swap(pos_a, pos_b);
 
-        let score = chi_square_score(&current_data);
+        let score = pair_delta_chi_square_score(&current_data);
         if score < best_score {
             best_score = score;
             best_perm = Permutation {
@@ -318,7 +320,7 @@ mod tests {
     fn camera_profile_yields_all_zeros_mask() {
         use crate::domain::ports::CameraProfile;
         let profile = CoverProfile::Camera(CameraProfile {
-            quantisation_table: vec![0u16; 64],
+            quantisation_table: [0u16; 64],
             noise_floor_db: -80.0,
             model_id: "canon".to_string(),
         });
@@ -365,7 +367,7 @@ mod tests {
         let data = vec![1u8, 2, 3, 4, 5, 6];
         let mask = BinMask::build(
             &CoverProfile::Camera(crate::domain::ports::CameraProfile {
-                quantisation_table: vec![0u16; 64],
+                quantisation_table: [0u16; 64],
                 noise_floor_db: -80.0,
                 model_id: "test".to_string(),
             }),
@@ -385,7 +387,7 @@ mod tests {
         let data: Vec<u8> = (0u8..64).collect();
         let mask = BinMask::build(
             &CoverProfile::Camera(crate::domain::ports::CameraProfile {
-                quantisation_table: vec![0u16; 64],
+                quantisation_table: [0u16; 64],
                 noise_floor_db: -80.0,
                 model_id: "test".to_string(),
             }),
@@ -403,7 +405,7 @@ mod tests {
         let data: Vec<u8> = vec![10, 20, 30, 40, 50];
         let mask = BinMask::build(
             &CoverProfile::Camera(crate::domain::ports::CameraProfile {
-                quantisation_table: vec![0u16; 64],
+                quantisation_table: [0u16; 64],
                 noise_floor_db: -80.0,
                 model_id: "test".to_string(),
             }),
@@ -436,7 +438,7 @@ mod tests {
         data.extend_from_slice(&[0u8; 256]); // add 256 zeros → heavily skewed histogram
         let mask = BinMask::build(
             &CoverProfile::Camera(crate::domain::ports::CameraProfile {
-                quantisation_table: vec![0u16; 64],
+                quantisation_table: [0u16; 64],
                 noise_floor_db: -80.0,
                 model_id: "test".to_string(),
             }),

--- a/crates/shadowforge/src/domain/adaptive/mod.rs
+++ b/crates/shadowforge/src/domain/adaptive/mod.rs
@@ -1,1 +1,449 @@
-//! Adversarial embedding optimisation, camera model profile matching, compression-survivable embedding.
+//! Adversarial embedding optimisation, camera model profile matching,
+//! compression-survivable embedding.
+//!
+//! Pure domain logic — no I/O, no file system, no async runtime.
+
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::domain::analysis::chi_square_score;
+use crate::domain::ports::CoverProfile;
+
+// ─── BinMask ─────────────────────────────────────────────────────────────────
+
+/// Occupancy mask for 2-D FFT bins, built from a [`CoverProfile`].
+///
+/// A `true` entry at `(row, col)` means that bin is occupied by a known
+/// external signal (e.g. an AI generator's watermark carrier) and **must
+/// not** be used for payload embedding.
+pub struct BinMask {
+    width: u32,
+    height: u32,
+    /// Row-major flat array; index = `row * width + col`.
+    occupied: Vec<bool>,
+}
+
+impl BinMask {
+    /// Build a bin-occupancy mask from `profile` at the given resolution.
+    ///
+    /// - `CoverProfile::Camera` → all-zeros (no protected bins).
+    /// - `CoverProfile::AiGenerator` → marks strong carrier bins (`coherence
+    ///   >= 0.90`).
+    #[must_use]
+    pub fn build(profile: &CoverProfile, width: u32, height: u32) -> Self {
+        let len = (width as usize).strict_mul(height as usize);
+        let mut occupied = vec![false; len];
+
+        if let CoverProfile::AiGenerator(p) = profile {
+            if let Some(bins) = p.carrier_bins_for(width, height) {
+                for bin in bins.iter().filter(|b| b.is_strong()) {
+                    let (row, col) = bin.freq;
+                    if row < height && col < width {
+                        let idx = (row as usize)
+                            .strict_mul(width as usize)
+                            .strict_add(col as usize);
+                        #[expect(
+                            clippy::indexing_slicing,
+                            reason = "idx < len is guaranteed by the row/col range check above"
+                        )]
+                        {
+                            occupied[idx] = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            width,
+            height,
+            occupied,
+        }
+    }
+
+    /// Return `true` if the bin at `(row, col)` is marked as occupied.
+    #[must_use]
+    pub fn is_occupied(&self, row: u32, col: u32) -> bool {
+        if row >= self.height || col >= self.width {
+            return false;
+        }
+        let idx = (row as usize)
+            .strict_mul(self.width as usize)
+            .strict_add(col as usize);
+        self.occupied.get(idx).copied().unwrap_or(false)
+    }
+
+    /// Return the number of occupied bins.
+    #[must_use]
+    pub fn occupied_count(&self) -> usize {
+        self.occupied.iter().filter(|&&b| b).count()
+    }
+
+    /// Total number of bins in the mask.
+    #[must_use]
+    pub fn total_bins(&self) -> usize {
+        self.occupied.len()
+    }
+}
+
+// ─── Cost function ───────────────────────────────────────────────────────────
+
+/// Per-bit-position distortion cost for the adaptive permutation search.
+///
+/// Returns `f64::INFINITY` for positions that map to occupied FFT bins.
+/// Returns a value in `1.0..=2.0` for safe bins — higher near
+/// moderate-coherence bins as a soft margin.
+#[must_use]
+pub fn cost_at(bit_position: usize, total_positions: usize, mask: &BinMask) -> f64 {
+    if total_positions == 0 {
+        return f64::INFINITY;
+    }
+
+    let col = (bit_position % mask.width as usize) as u32;
+    let row = (bit_position / mask.width.max(1) as usize) as u32;
+
+    if mask.is_occupied(row, col) {
+        return f64::INFINITY;
+    }
+
+    // Soft margin: positions near the boundary of occupied regions get a
+    // slightly higher cost (up to 2.0).  We use the fractional position
+    // within the image as a proxy for proximity to occupied areas.
+    let fraction = bit_position as f64 / total_positions as f64;
+    1.0 + fraction.min(1.0)
+}
+
+// ─── Permutation ─────────────────────────────────────────────────────────────
+
+/// A bit-position permutation derived from a cost-weighted PRNG walk.
+///
+/// `map[original_position] = new_position`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Permutation {
+    map: Vec<usize>,
+}
+
+impl Permutation {
+    /// Identity permutation — no reordering.
+    #[must_use]
+    pub fn identity(len: usize) -> Self {
+        Self {
+            map: (0..len).collect(),
+        }
+    }
+
+    /// Apply the permutation to `data` in-place (cycle-following algorithm).
+    pub fn apply(&self, data: &mut [u8]) {
+        let n = data.len().min(self.map.len());
+        let mut visited = vec![false; n];
+
+        for start in 0..n {
+            if visited[start] || self.map.get(start).copied().unwrap_or(start) == start {
+                visited[start] = true;
+                continue;
+            }
+
+            // Follow the cycle collecting original values.
+            let saved = data[start];
+            let mut current = start;
+            loop {
+                let next = self.map.get(current).copied().unwrap_or(current);
+                visited[current] = true;
+                if next == start {
+                    data[current] = saved;
+                    break;
+                }
+                data[current] = data[next];
+                current = next;
+            }
+        }
+    }
+
+    /// Return the inverse permutation  such that `inv.apply(p.apply(x)) == x`.
+    #[must_use]
+    pub fn inverse(&self) -> Self {
+        let mut inv = vec![0usize; self.map.len()];
+        for (orig, &new_pos) in self.map.iter().enumerate() {
+            if new_pos < inv.len() {
+                #[expect(
+                    clippy::indexing_slicing,
+                    reason = "new_pos is within bounds by the range-check above"
+                )]
+                {
+                    inv[new_pos] = orig;
+                }
+            }
+        }
+        Self { map: inv }
+    }
+
+    /// Raw permutation map (original_position → new_position).
+    #[must_use]
+    pub fn as_slice(&self) -> &[usize] {
+        &self.map
+    }
+}
+
+// ─── SearchConfig ────────────────────────────────────────────────────────────
+
+/// Permutation search configuration.
+#[derive(Debug, Clone)]
+pub struct SearchConfig {
+    /// Maximum number of candidate permutations to evaluate.
+    pub max_iterations: u32,
+    /// Target chi-square score (dB) — search stops early when reached.
+    pub target_db: f64,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: 100,
+            target_db: -12.0,
+        }
+    }
+}
+
+// ─── permutation_search ──────────────────────────────────────────────────────
+
+/// Find the lowest-detectability permutation within `config.max_iterations`.
+///
+/// `seed` must be derived from the crypto key — never use a fresh random seed
+/// (the receiver needs to reconstruct the same permutation for extraction).
+///
+/// Uses a random-restart hill-climb: each iteration proposes a swap of two
+/// positions and accepts it if it lowers the chi-square score.
+#[must_use]
+pub fn permutation_search(
+    stego_bytes: &[u8],
+    mask: &BinMask,
+    config: &SearchConfig,
+    seed: u64,
+) -> Permutation {
+    if stego_bytes.is_empty() || config.max_iterations == 0 {
+        return Permutation::identity(stego_bytes.len());
+    }
+
+    use rand::RngExt as _;
+
+    let n = stego_bytes.len();
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut best_perm = Permutation::identity(n);
+    let mut best_score = chi_square_score(stego_bytes);
+
+    // Collect safe (non-occupied) positions to limit candidate swaps.
+    let safe_positions: Vec<usize> = (0..n)
+        .filter(|&pos| cost_at(pos, n, mask).is_finite())
+        .collect();
+
+    if safe_positions.len() < 2 {
+        return best_perm;
+    }
+
+    let mut current_map = best_perm.map.clone();
+    let mut current_data = stego_bytes.to_vec();
+
+    for _ in 0..config.max_iterations {
+        // Pick two distinct safe positions.
+        let idx_a = rng.random_range(0..safe_positions.len());
+        let mut idx_b = rng.random_range(0..safe_positions.len());
+        while idx_b == idx_a {
+            idx_b = rng.random_range(0..safe_positions.len());
+        }
+        let pos_a = safe_positions[idx_a];
+        let pos_b = safe_positions[idx_b];
+
+        // Tentatively swap in both the map and the data.
+        current_map.swap(pos_a, pos_b);
+        current_data.swap(pos_a, pos_b);
+
+        let score = chi_square_score(&current_data);
+        if score < best_score {
+            best_score = score;
+            best_perm = Permutation {
+                map: current_map.clone(),
+            };
+            if best_score <= config.target_db {
+                break;
+            }
+        } else {
+            // Revert.
+            current_map.swap(pos_a, pos_b);
+            current_data.swap(pos_a, pos_b);
+        }
+    }
+
+    best_perm
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::ports::{AiGenProfile, CarrierBin, CoverProfile};
+    use std::collections::HashMap;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    fn gemini_1024_profile() -> CoverProfile {
+        let bins = vec![
+            CarrierBin::new((9, 9), 0.0, 1.0),
+            CarrierBin::new((5, 5), 0.0, 1.0),
+            CarrierBin::new((10, 11), 0.0, 1.0),
+            CarrierBin::new((13, 6), 0.0, 0.82), // below 0.90 — NOT strong
+        ];
+        let mut carrier_map = HashMap::new();
+        carrier_map.insert("1024x1024".to_string(), bins);
+        CoverProfile::AiGenerator(AiGenProfile {
+            model_id: "gemini".to_string(),
+            channel_weights: [0.85, 1.0, 0.70],
+            carrier_map,
+        })
+    }
+
+    #[test]
+    fn camera_profile_yields_all_zeros_mask() {
+        use crate::domain::ports::CameraProfile;
+        let profile = CoverProfile::Camera(CameraProfile {
+            quantisation_table: vec![0u16; 64],
+            noise_floor_db: -80.0,
+            model_id: "canon".to_string(),
+        });
+        let mask = BinMask::build(&profile, 64, 64);
+        assert_eq!(mask.occupied_count(), 0);
+    }
+
+    #[test]
+    fn ai_gen_profile_marks_strong_carrier_bins() {
+        let profile = gemini_1024_profile();
+        let mask = BinMask::build(&profile, 1024, 1024);
+        // (9,9), (5,5), (10,11) are strong; (13,6) has coherence 0.82 — not marked
+        assert!(mask.is_occupied(9, 9));
+        assert!(mask.is_occupied(5, 5));
+        assert!(mask.is_occupied(10, 11));
+        assert!(!mask.is_occupied(13, 6)); // below 0.90
+        assert!(!mask.is_occupied(100, 100));
+        assert_eq!(mask.occupied_count(), 3);
+    }
+
+    #[test]
+    fn cost_at_returns_infinity_for_occupied_bin() {
+        let profile = gemini_1024_profile();
+        let mask = BinMask::build(&profile, 1024, 1024);
+        // Position for (row=9, col=9): index = 9 * 1024 + 9 = 9225
+        let occupied_position = 9usize * 1024 + 9;
+        let cost = cost_at(occupied_position, 1024 * 1024, &mask);
+        assert!(cost.is_infinite(), "expected infinity for occupied bin");
+    }
+
+    #[test]
+    fn cost_at_returns_finite_for_safe_bin() {
+        let profile = gemini_1024_profile();
+        let mask = BinMask::build(&profile, 1024, 1024);
+        let safe_position = 500usize;
+        let cost = cost_at(safe_position, 1024 * 1024, &mask);
+        assert!(cost.is_finite());
+        assert!(cost >= 1.0);
+        assert!(cost <= 2.0);
+    }
+
+    #[test]
+    fn permutation_zero_iterations_returns_identity() {
+        let data = vec![1u8, 2, 3, 4, 5, 6];
+        let mask = BinMask::build(
+            &CoverProfile::Camera(crate::domain::ports::CameraProfile {
+                quantisation_table: vec![0u16; 64],
+                noise_floor_db: -80.0,
+                model_id: "test".to_string(),
+            }),
+            6,
+            1,
+        );
+        let config = SearchConfig {
+            max_iterations: 0,
+            target_db: -12.0,
+        };
+        let perm = permutation_search(&data, &mask, &config, 42);
+        assert_eq!(perm, Permutation::identity(6));
+    }
+
+    #[test]
+    fn permutation_is_deterministic_same_seed() {
+        let data: Vec<u8> = (0u8..64).collect();
+        let mask = BinMask::build(
+            &CoverProfile::Camera(crate::domain::ports::CameraProfile {
+                quantisation_table: vec![0u16; 64],
+                noise_floor_db: -80.0,
+                model_id: "test".to_string(),
+            }),
+            8,
+            8,
+        );
+        let config = SearchConfig::default();
+        let p1 = permutation_search(&data, &mask, &config, 12345);
+        let p2 = permutation_search(&data, &mask, &config, 12345);
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn permutation_inverse_round_trips() {
+        let data: Vec<u8> = vec![10, 20, 30, 40, 50];
+        let mask = BinMask::build(
+            &CoverProfile::Camera(crate::domain::ports::CameraProfile {
+                quantisation_table: vec![0u16; 64],
+                noise_floor_db: -80.0,
+                model_id: "test".to_string(),
+            }),
+            5,
+            1,
+        );
+        let config = SearchConfig::default();
+        let perm = permutation_search(&data, &mask, &config, 99);
+        let original = data.clone();
+        let mut modified = data;
+        perm.apply(&mut modified);
+        perm.inverse().apply(&mut modified);
+        assert_eq!(modified, original);
+    }
+
+    #[test]
+    fn permutation_identity_apply_is_noop() -> TestResult {
+        let original = vec![1u8, 2, 3, 4];
+        let mut data = original.clone();
+        let perm = Permutation::identity(4);
+        perm.apply(&mut data);
+        assert_eq!(data, original);
+        Ok(())
+    }
+
+    #[test]
+    fn permutation_search_may_improve_score() {
+        // Build stego data with a known non-uniform pattern.
+        // The permutation search may find a better ordering.
+        let mut data: Vec<u8> = (0u8..=255u8).collect();
+        data.extend_from_slice(&[0u8; 256]); // add 256 zeros → heavily skewed histogram
+        let mask = BinMask::build(
+            &CoverProfile::Camera(crate::domain::ports::CameraProfile {
+                quantisation_table: vec![0u16; 64],
+                noise_floor_db: -80.0,
+                model_id: "test".to_string(),
+            }),
+            16,
+            32,
+        );
+        let config = SearchConfig {
+            max_iterations: 100,
+            target_db: -12.0,
+        };
+        let perm = permutation_search(&data, &mask, &config, 777);
+        // The permutation must be the right size.
+        assert_eq!(perm.as_slice().len(), data.len());
+        // After applying and inverting we must recover the original.
+        let original = data.clone();
+        let mut applied = data;
+        perm.apply(&mut applied);
+        perm.inverse().apply(&mut applied);
+        assert_eq!(applied, original);
+    }
+}

--- a/crates/shadowforge/src/domain/analysis/mod.rs
+++ b/crates/shadowforge/src/domain/analysis/mod.rs
@@ -221,10 +221,11 @@ pub fn spectral_detectability_score(
 
     // Determine image width: try to find a power-of-two width that matches.
     // For analysis we use fft_len itself as width; height = 1 (1-D DFT).
-    let (width, height) = (fft_len as u32, 1u32);
+    let width = u32::try_from(fft_len).ok().map_or(u32::MAX, |v| v);
+    let height = 1u32;
 
     // Determine carrier bins to examine.
-    let carrier_bins: Vec<(u32, u32)> = if let Some(prof) = profile {
+    let carrier_bins: Vec<(u32, u32)> = profile.map_or_else(Vec::new, |prof| {
         prof.carrier_bins_for(width, height)
             .map(|bins| {
                 bins.iter()
@@ -233,9 +234,7 @@ pub fn spectral_detectability_score(
                     .collect()
             })
             .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
+    });
 
     let carrier_bins: Vec<(usize, usize)> = if carrier_bins.is_empty() {
         // Fall back to top-16 highest magnitude bins, skipping DC.
@@ -254,8 +253,10 @@ pub fn spectral_detectability_score(
     let carrier_snr_drop_db = compute_carrier_snr_drop_db(&orig_freq, &stego_freq, &carrier_bins);
 
     // Sample-pair adjacency asymmetry on the raw channel.
-    let sample_pair_asymmetry =
-        compute_sample_pair_asymmetry(&orig_pixels[..n], &stego_pixels[..n]);
+    let sample_pair_asymmetry = match (orig_pixels.get(..n), stego_pixels.get(..n)) {
+        (Some(orig), Some(stego)) => compute_sample_pair_asymmetry(orig, stego),
+        _ => 0.0,
+    };
 
     let combined_risk = classify_spectral_risk(phase_coherence_drop, carrier_snr_drop_db);
 
@@ -273,10 +274,15 @@ pub fn spectral_detectability_score(
 /// Bytes are interpreted as RGBA8; if length isn't divisible by 4 the
 /// remainder bytes are treated as green-channel samples directly.
 fn green_channel_f32(data: &Bytes) -> Vec<f32> {
-    if data.len() >= 4 && data.len() % 4 == 0 {
-        data.chunks_exact(4).map(|ch| ch[1] as f32).collect()
+    if data.len() >= 4 && data.len().is_multiple_of(4) {
+        data.chunks_exact(4)
+            .filter_map(|ch| match ch {
+                [_, g, _, _] => Some(f32::from(*g)),
+                _ => None,
+            })
+            .collect()
     } else {
-        data.iter().map(|&b| b as f32).collect()
+        data.iter().map(|&b| f32::from(b)).collect()
     }
 }
 
@@ -298,14 +304,14 @@ fn top_magnitude_bins(freq: &[Complex<f32>], n: usize) -> Vec<(usize, usize)> {
         .iter()
         .enumerate()
         .skip(1)
-        .map(|(i, c)| (i, c.norm() as f64))
+        .map(|(i, c)| (i, f64::from(c.norm())))
         .collect();
     indexed.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     indexed.truncate(n);
     indexed.into_iter().map(|(i, _)| (0usize, i)).collect()
 }
 
-/// 1 − avg |cos(phase_stego − phase_orig)| over the given bins.
+/// `1 - avg(|cos(phase_stego - phase_orig)|)` over the given bins.
 fn compute_phase_coherence_drop(
     orig: &[Complex<f32>],
     stego: &[Complex<f32>],
@@ -318,7 +324,7 @@ fn compute_phase_coherence_drop(
     let mut count = 0usize;
     for &(_row, col) in bins {
         if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
-            let phase_diff = (s.arg() - o.arg()) as f64;
+            let phase_diff = f64::from(s.arg() - o.arg());
             sum += phase_diff.cos().abs();
             count = count.strict_add(1);
         }
@@ -326,7 +332,11 @@ fn compute_phase_coherence_drop(
     if count == 0 {
         return 0.0;
     }
-    let avg_coherence = sum / count as f64;
+    let count_f = match u32::try_from(count) {
+        Ok(v) => f64::from(v),
+        Err(_) => return 0.0,
+    };
+    let avg_coherence = sum / count_f;
     (1.0 - avg_coherence).clamp(0.0, 1.0)
 }
 
@@ -344,8 +354,8 @@ fn compute_carrier_snr_drop_db(
     let mut count = 0usize;
     for &(_row, col) in bins {
         if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
-            let mag_orig = o.norm() as f64;
-            let mag_stego = s.norm() as f64;
+            let mag_orig = f64::from(o.norm());
+            let mag_stego = f64::from(s.norm());
             if mag_orig > 0.0 && mag_stego > 0.0 {
                 sum += 10.0 * (mag_stego / mag_orig).log10();
                 count = count.strict_add(1);
@@ -355,7 +365,11 @@ fn compute_carrier_snr_drop_db(
     if count == 0 {
         return 0.0;
     }
-    let result = sum / count as f64;
+    let count_f = match u32::try_from(count) {
+        Ok(v) => f64::from(v),
+        Err(_) => return 0.0,
+    };
+    let result = sum / count_f;
     if result.is_nan() { 0.0 } else { result }
 }
 
@@ -366,18 +380,43 @@ fn compute_sample_pair_asymmetry(orig: &[f32], stego: &[f32]) -> f64 {
     if stego.len() < 2 {
         return 0.0;
     }
+
     let pairs = stego.len() / 2;
     let asym: usize = stego
         .chunks_exact(2)
-        .filter(|pair| (pair[0] as u8 & 1) != (pair[1] as u8 & 1))
+        .filter(|pair| match pair {
+            [a, b] => sample_is_odd(*a) != sample_is_odd(*b),
+            _ => false,
+        })
         .count();
     let orig_asym: usize = orig
         .chunks_exact(2)
-        .filter(|pair| (pair[0] as u8 & 1) != (pair[1] as u8 & 1))
+        .filter(|pair| match pair {
+            [a, b] => sample_is_odd(*a) != sample_is_odd(*b),
+            _ => false,
+        })
         .count();
-    let stego_frac = asym as f64 / pairs as f64;
-    let orig_frac = orig_asym as f64 / pairs as f64;
+    let pairs_f = match u32::try_from(pairs) {
+        Ok(v) if v > 0 => f64::from(v),
+        _ => return 0.0,
+    };
+    let asym_f = match u32::try_from(asym) {
+        Ok(v) => f64::from(v),
+        Err(_) => return 0.0,
+    };
+    let orig_asym_f = match u32::try_from(orig_asym) {
+        Ok(v) => f64::from(v),
+        Err(_) => return 0.0,
+    };
+    let stego_frac = asym_f / pairs_f;
+    let orig_frac = orig_asym_f / pairs_f;
     (stego_frac - orig_frac).abs().clamp(0.0, 1.0)
+}
+
+fn sample_is_odd(sample: f32) -> bool {
+    // Samples are originally byte-derived channel values represented as f32.
+    // Using float parity avoids lossy integer casts that violate strict lints.
+    sample.rem_euclid(2.0) >= 1.0
 }
 
 /// Classify spectral risk based on phase coherence drop and SNR drop.
@@ -703,8 +742,16 @@ mod tests {
             sample_pair_asymmetry: 0.03,
             combined_risk: DetectabilityRisk::Medium,
         };
-        let json = serde_json::to_string(&score).expect("serialise");
-        let back: SpectralScore = serde_json::from_str(&json).expect("deserialise");
+        let json = serde_json::to_string(&score);
+        assert!(json.is_ok());
+        let Some(json) = json.ok() else {
+            return;
+        };
+        let back: Result<SpectralScore, _> = serde_json::from_str(&json);
+        assert!(back.is_ok());
+        let Some(back) = back.ok() else {
+            return;
+        };
         assert!((back.phase_coherence_drop - score.phase_coherence_drop).abs() < 1e-10);
         assert!((back.carrier_snr_drop_db - score.carrier_snr_drop_db).abs() < 1e-10);
         assert_eq!(back.combined_risk, score.combined_risk);

--- a/crates/shadowforge/src/domain/analysis/mod.rs
+++ b/crates/shadowforge/src/domain/analysis/mod.rs
@@ -115,6 +115,61 @@ pub fn chi_square_score(data: &[u8]) -> f64 {
     }
 }
 
+/// Compute a pair-delta chi-square score on `data`.
+///
+/// Builds a 256-bin histogram of consecutive byte differences
+/// `data[i+1].wrapping_sub(data[i])` and measures how far that distribution
+/// deviates from the flat prior expected for independent random bytes.
+/// Lower score = less detectable.
+///
+/// Unlike [`chi_square_score`], this score **is** order-sensitive: swapping
+/// two non-adjacent bytes changes the pairs they participate in and therefore
+/// changes the score.  This makes it suitable as the hill-climb objective in
+/// [`crate::domain::adaptive::permutation_search`].
+#[must_use]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "pair counts are small enough for f64"
+)]
+pub fn pair_delta_chi_square_score(data: &[u8]) -> f64 {
+    if data.len() < 2 {
+        return 0.0;
+    }
+
+    let mut histogram = [0u64; 256];
+    for pair in data.array_windows::<2>() {
+        let delta = pair[1].wrapping_sub(pair[0]);
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "delta is a u8, always 0..=255, histogram has 256 entries"
+        )]
+        {
+            histogram[usize::from(delta)] = histogram[usize::from(delta)].strict_add(1);
+        }
+    }
+
+    let n_pairs = data.len().strict_sub(1);
+    let expected = n_pairs as f64 / 256.0;
+    if expected < f64::EPSILON {
+        return 0.0;
+    }
+
+    let chi_sq: f64 = histogram
+        .iter()
+        .map(|&count| {
+            let diff = count as f64 - expected;
+            (diff * diff) / expected
+        })
+        .sum();
+
+    let normalised = chi_sq / 255.0;
+    if normalised < f64::EPSILON {
+        -100.0
+    } else {
+        10.0 * normalised.log10()
+    }
+}
+
 // ─── Private capacity estimators ──────────────────────────────────────────────
 
 const fn estimate_image_lsb_capacity(cover: &CoverMedia) -> u64 {
@@ -219,12 +274,25 @@ pub fn spectral_detectability_score(
     let orig_freq = run_fft(&orig_pixels, fft_len);
     let stego_freq = run_fft(&stego_pixels, fft_len);
 
-    // Determine image width: try to find a power-of-two width that matches.
-    // For analysis we use fft_len itself as width; height = 1 (1-D DFT).
-    let width = u32::try_from(fft_len).ok().map_or(u32::MAX, |v| v);
-    let height = 1u32;
+    // Extract actual image dimensions from metadata so the carrier-bin
+    // profile lookup (keyed by "WIDTHxHEIGHT") can find the right entry.
+    // Fall back to treating the data as a 1-D signal if dimensions are absent.
+    let img_width: usize = original
+        .metadata
+        .get("width")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(fft_len);
+    let img_height: usize = original
+        .metadata
+        .get("height")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(1);
+    let width = u32::try_from(img_width).unwrap_or(u32::MAX);
+    let height = u32::try_from(img_height).unwrap_or(u32::MAX);
 
-    // Determine carrier bins to examine.
+    // Determine carrier bins to examine.  Convert (row, col) 2-D coordinates
+    // to a flat 1-D FFT index so the helpers can index directly into the
+    // FFT output array.
     let carrier_bins: Vec<(u32, u32)> = profile.map_or_else(Vec::new, |prof| {
         prof.carrier_bins_for(width, height)
             .map(|bins| {
@@ -236,21 +304,25 @@ pub fn spectral_detectability_score(
             .unwrap_or_default()
     });
 
-    let carrier_bins: Vec<(usize, usize)> = if carrier_bins.is_empty() {
+    let flat_bins: Vec<usize> = if carrier_bins.is_empty() {
         // Fall back to top-16 highest magnitude bins, skipping DC.
         top_magnitude_bins(&orig_freq, 16)
     } else {
         carrier_bins
             .into_iter()
-            .map(|(r, c)| (r as usize, c as usize))
+            .map(|(r, c)| {
+                (r as usize)
+                    .saturating_mul(img_width)
+                    .saturating_add(c as usize)
+            })
             .collect()
     };
 
     // Phase coherence drop: 1 − avg |cos(Δphase)| over carrier bins.
-    let phase_coherence_drop = compute_phase_coherence_drop(&orig_freq, &stego_freq, &carrier_bins);
+    let phase_coherence_drop = compute_phase_coherence_drop(&orig_freq, &stego_freq, &flat_bins);
 
     // SNR drop in dB.
-    let carrier_snr_drop_db = compute_carrier_snr_drop_db(&orig_freq, &stego_freq, &carrier_bins);
+    let carrier_snr_drop_db = compute_carrier_snr_drop_db(&orig_freq, &stego_freq, &flat_bins);
 
     // Sample-pair adjacency asymmetry on the raw channel.
     let sample_pair_asymmetry = match (orig_pixels.get(..n), stego_pixels.get(..n)) {
@@ -297,9 +369,9 @@ fn run_fft(samples: &[f32], fft_len: usize) -> Vec<Complex<f32>> {
     input
 }
 
-/// Return indices `(0, bin)` of the top-`n` highest-magnitude bins, skipping
-/// DC (index 0).
-fn top_magnitude_bins(freq: &[Complex<f32>], n: usize) -> Vec<(usize, usize)> {
+/// Return flat 1-D FFT bin indices of the top-`n` highest-magnitude bins,
+/// skipping DC (index 0).
+fn top_magnitude_bins(freq: &[Complex<f32>], n: usize) -> Vec<usize> {
     let mut indexed: Vec<(usize, f64)> = freq
         .iter()
         .enumerate()
@@ -308,22 +380,22 @@ fn top_magnitude_bins(freq: &[Complex<f32>], n: usize) -> Vec<(usize, usize)> {
         .collect();
     indexed.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     indexed.truncate(n);
-    indexed.into_iter().map(|(i, _)| (0usize, i)).collect()
+    indexed.into_iter().map(|(i, _)| i).collect()
 }
 
-/// `1 - avg(|cos(phase_stego - phase_orig)|)` over the given bins.
+/// `1 - avg(|cos(phase_stego - phase_orig)|)` over the given flat bin indices.
 fn compute_phase_coherence_drop(
     orig: &[Complex<f32>],
     stego: &[Complex<f32>],
-    bins: &[(usize, usize)],
+    bins: &[usize],
 ) -> f64 {
     if bins.is_empty() {
         return 0.0;
     }
     let mut sum = 0.0f64;
     let mut count = 0usize;
-    for &(_row, col) in bins {
-        if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
+    for &idx in bins {
+        if let (Some(o), Some(s)) = (orig.get(idx), stego.get(idx)) {
             let phase_diff = f64::from(s.arg() - o.arg());
             sum += phase_diff.cos().abs();
             count = count.strict_add(1);
@@ -345,15 +417,15 @@ fn compute_phase_coherence_drop(
 fn compute_carrier_snr_drop_db(
     orig: &[Complex<f32>],
     stego: &[Complex<f32>],
-    bins: &[(usize, usize)],
+    bins: &[usize],
 ) -> f64 {
     if bins.is_empty() {
         return 0.0;
     }
     let mut sum = 0.0f64;
     let mut count = 0usize;
-    for &(_row, col) in bins {
-        if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
+    for &idx in bins {
+        if let (Some(o), Some(s)) = (orig.get(idx), stego.get(idx)) {
             let mag_orig = f64::from(o.norm());
             let mag_stego = f64::from(s.norm());
             if mag_orig > 0.0 && mag_stego > 0.0 {

--- a/crates/shadowforge/src/domain/analysis/mod.rs
+++ b/crates/shadowforge/src/domain/analysis/mod.rs
@@ -1,8 +1,16 @@
-//! Capacity estimation and chi-square detectability analysis.
+//! Capacity estimation and chi-square detectability analysis, plus
+//! spectral-domain detectability scoring.
 //!
 //! Pure domain logic — no I/O, no file system, no async runtime.
 
-use crate::domain::types::{CoverMedia, CoverMediaKind, DetectabilityRisk, StegoTechnique};
+use bytes::Bytes;
+use rustfft::FftPlanner;
+use rustfft::num_complex::Complex;
+
+use crate::domain::ports::AiGenProfile;
+use crate::domain::types::{
+    CoverMedia, CoverMediaKind, DetectabilityRisk, SpectralScore, StegoTechnique,
+};
 
 /// `DetectabilityRisk` thresholds in dB.
 const HIGH_THRESHOLD_DB: f64 = -6.0;
@@ -173,6 +181,217 @@ fn estimate_pdf_content_capacity(cover: &CoverMedia) -> u64 {
 const fn estimate_pdf_metadata_capacity(_cover: &CoverMedia) -> u64 {
     // Metadata fields: limited capacity (~256 bytes typical)
     256
+}
+
+// ─── Spectral detectability scoring ──────────────────────────────────────────
+
+/// Run a spectral-domain detectability analysis comparing `original` to
+/// `stego`.
+///
+/// The score is profile-aware: when an [`AiGenProfile`] is provided, only the
+/// carrier bins with `coherence >= 0.90` are analysed.  Without a profile the
+/// top-16 highest-magnitude bins (excluding DC at `(0, 0)`) are used.
+///
+/// # Panics
+///
+/// Never panics.  Empty and single-pixel inputs are handled gracefully.
+#[must_use]
+pub fn spectral_detectability_score(
+    original: &CoverMedia,
+    stego: &CoverMedia,
+    profile: Option<&AiGenProfile>,
+) -> SpectralScore {
+    let orig_pixels = green_channel_f32(&original.data);
+    let stego_pixels = green_channel_f32(&stego.data);
+
+    let n = orig_pixels.len().min(stego_pixels.len());
+    if n < 4 {
+        return SpectralScore {
+            phase_coherence_drop: 0.0,
+            carrier_snr_drop_db: 0.0,
+            sample_pair_asymmetry: 0.0,
+            combined_risk: DetectabilityRisk::Low,
+        };
+    }
+
+    // Next power-of-two >= n for FFT.
+    let fft_len = n.next_power_of_two();
+    let orig_freq = run_fft(&orig_pixels, fft_len);
+    let stego_freq = run_fft(&stego_pixels, fft_len);
+
+    // Determine image width: try to find a power-of-two width that matches.
+    // For analysis we use fft_len itself as width; height = 1 (1-D DFT).
+    let (width, height) = (fft_len as u32, 1u32);
+
+    // Determine carrier bins to examine.
+    let carrier_bins: Vec<(u32, u32)> = if let Some(prof) = profile {
+        prof.carrier_bins_for(width, height)
+            .map(|bins| {
+                bins.iter()
+                    .filter(|b| b.is_strong())
+                    .map(|b| b.freq)
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    let carrier_bins: Vec<(usize, usize)> = if carrier_bins.is_empty() {
+        // Fall back to top-16 highest magnitude bins, skipping DC.
+        top_magnitude_bins(&orig_freq, 16)
+    } else {
+        carrier_bins
+            .into_iter()
+            .map(|(r, c)| (r as usize, c as usize))
+            .collect()
+    };
+
+    // Phase coherence drop: 1 − avg |cos(Δphase)| over carrier bins.
+    let phase_coherence_drop = compute_phase_coherence_drop(&orig_freq, &stego_freq, &carrier_bins);
+
+    // SNR drop in dB.
+    let carrier_snr_drop_db = compute_carrier_snr_drop_db(&orig_freq, &stego_freq, &carrier_bins);
+
+    // Sample-pair adjacency asymmetry on the raw channel.
+    let sample_pair_asymmetry =
+        compute_sample_pair_asymmetry(&orig_pixels[..n], &stego_pixels[..n]);
+
+    let combined_risk = classify_spectral_risk(phase_coherence_drop, carrier_snr_drop_db);
+
+    SpectralScore {
+        phase_coherence_drop,
+        carrier_snr_drop_db,
+        sample_pair_asymmetry,
+        combined_risk,
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Extract the green channel as `f32` values from RGBA8-packed bytes.
+/// Bytes are interpreted as RGBA8; if length isn't divisible by 4 the
+/// remainder bytes are treated as green-channel samples directly.
+fn green_channel_f32(data: &Bytes) -> Vec<f32> {
+    if data.len() >= 4 && data.len() % 4 == 0 {
+        data.chunks_exact(4).map(|ch| ch[1] as f32).collect()
+    } else {
+        data.iter().map(|&b| b as f32).collect()
+    }
+}
+
+/// Run a 1-D FFT on `samples`, zero-padded to `fft_len`.
+fn run_fft(samples: &[f32], fft_len: usize) -> Vec<Complex<f32>> {
+    let mut input: Vec<Complex<f32>> = samples.iter().map(|&x| Complex::new(x, 0.0)).collect();
+    input.resize(fft_len, Complex::new(0.0, 0.0));
+
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(fft_len);
+    fft.process(&mut input);
+    input
+}
+
+/// Return indices `(0, bin)` of the top-`n` highest-magnitude bins, skipping
+/// DC (index 0).
+fn top_magnitude_bins(freq: &[Complex<f32>], n: usize) -> Vec<(usize, usize)> {
+    let mut indexed: Vec<(usize, f64)> = freq
+        .iter()
+        .enumerate()
+        .skip(1)
+        .map(|(i, c)| (i, c.norm() as f64))
+        .collect();
+    indexed.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    indexed.truncate(n);
+    indexed.into_iter().map(|(i, _)| (0usize, i)).collect()
+}
+
+/// 1 − avg |cos(phase_stego − phase_orig)| over the given bins.
+fn compute_phase_coherence_drop(
+    orig: &[Complex<f32>],
+    stego: &[Complex<f32>],
+    bins: &[(usize, usize)],
+) -> f64 {
+    if bins.is_empty() {
+        return 0.0;
+    }
+    let mut sum = 0.0f64;
+    let mut count = 0usize;
+    for &(_row, col) in bins {
+        if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
+            let phase_diff = (s.arg() - o.arg()) as f64;
+            sum += phase_diff.cos().abs();
+            count = count.strict_add(1);
+        }
+    }
+    if count == 0 {
+        return 0.0;
+    }
+    let avg_coherence = sum / count as f64;
+    (1.0 - avg_coherence).clamp(0.0, 1.0)
+}
+
+/// Mean SNR drop in dB: 10·log10(|stego|/|orig|) averaged over carrier bins.
+/// Returns 0.0 when no bins are available or magnitudes are zero.
+fn compute_carrier_snr_drop_db(
+    orig: &[Complex<f32>],
+    stego: &[Complex<f32>],
+    bins: &[(usize, usize)],
+) -> f64 {
+    if bins.is_empty() {
+        return 0.0;
+    }
+    let mut sum = 0.0f64;
+    let mut count = 0usize;
+    for &(_row, col) in bins {
+        if let (Some(o), Some(s)) = (orig.get(col), stego.get(col)) {
+            let mag_orig = o.norm() as f64;
+            let mag_stego = s.norm() as f64;
+            if mag_orig > 0.0 && mag_stego > 0.0 {
+                sum += 10.0 * (mag_stego / mag_orig).log10();
+                count = count.strict_add(1);
+            }
+        }
+    }
+    if count == 0 {
+        return 0.0;
+    }
+    let result = sum / count as f64;
+    if result.is_nan() { 0.0 } else { result }
+}
+
+/// Adjacent pixel-pair parity asymmetry in the stego channel:
+/// fraction of pairs where even-position sample differs from odd-position
+/// sample in parity (LSB) more than expected.
+fn compute_sample_pair_asymmetry(orig: &[f32], stego: &[f32]) -> f64 {
+    if stego.len() < 2 {
+        return 0.0;
+    }
+    let pairs = stego.len() / 2;
+    let asym: usize = stego
+        .chunks_exact(2)
+        .filter(|pair| (pair[0] as u8 & 1) != (pair[1] as u8 & 1))
+        .count();
+    let orig_asym: usize = orig
+        .chunks_exact(2)
+        .filter(|pair| (pair[0] as u8 & 1) != (pair[1] as u8 & 1))
+        .count();
+    let stego_frac = asym as f64 / pairs as f64;
+    let orig_frac = orig_asym as f64 / pairs as f64;
+    (stego_frac - orig_frac).abs().clamp(0.0, 1.0)
+}
+
+/// Classify spectral risk based on phase coherence drop and SNR drop.
+fn classify_spectral_risk(
+    phase_coherence_drop: f64,
+    carrier_snr_drop_db: f64,
+) -> DetectabilityRisk {
+    if phase_coherence_drop > 0.20 || carrier_snr_drop_db.abs() > 0.15 {
+        DetectabilityRisk::High
+    } else if phase_coherence_drop > 0.05 || carrier_snr_drop_db.abs() > 0.05 {
+        DetectabilityRisk::Medium
+    } else {
+        DetectabilityRisk::Low
+    }
 }
 
 #[cfg(test)]
@@ -391,5 +610,120 @@ mod tests {
         let cover = make_cover(CoverMediaKind::PngImage, 4096);
         let cap = estimate_capacity(&cover, StegoTechnique::Palette);
         assert_eq!(cap, 124); // Same formula as GIF
+    }
+
+    // ─── Spectral detectability score tests ──────────────────────────────
+
+    fn make_spectral_cover(data: Vec<u8>) -> CoverMedia {
+        CoverMedia {
+            kind: CoverMediaKind::PngImage,
+            data: Bytes::from(data),
+            metadata: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn spectral_identical_buffers_low_risk() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(1024).collect();
+        let orig = make_spectral_cover(data.clone());
+        let stego = make_spectral_cover(data);
+        let score = spectral_detectability_score(&orig, &stego, None);
+        assert!(
+            (score.phase_coherence_drop).abs() < 1e-6,
+            "identical buffers: phase_coherence_drop should be ~0"
+        );
+        assert!(
+            (score.carrier_snr_drop_db).abs() < 1e-3,
+            "identical buffers: carrier_snr_drop_db should be ~0"
+        );
+        assert_eq!(score.combined_risk, DetectabilityRisk::Low);
+    }
+
+    #[test]
+    fn spectral_heavily_modified_differs_from_identical() {
+        // Inverted data has a very different spectrum from the original.
+        // The score fields should reflect numeric differences; we only
+        // assert the scoring completes without panic and produces a valid
+        // risk level (the exact threshold depends on the data content).
+        let orig_data: Vec<u8> = (0u8..=255).cycle().take(1024).collect();
+        let stego_data: Vec<u8> = orig_data.iter().map(|&b| b ^ 0xFF).collect();
+        let orig = make_spectral_cover(orig_data);
+        let stego = make_spectral_cover(stego_data);
+        let score = spectral_detectability_score(&orig, &stego, None);
+        // Score fields must be finite and non-negative where applicable.
+        assert!(score.phase_coherence_drop.is_finite());
+        assert!(score.sample_pair_asymmetry >= 0.0);
+        // Risk must be a valid variant — just confirming it doesn't panic.
+        let _ = score.combined_risk;
+    }
+
+    #[test]
+    fn spectral_empty_orig_no_panic() {
+        let orig = make_spectral_cover(vec![]);
+        let stego = make_spectral_cover(vec![0u8; 64]);
+        let score = spectral_detectability_score(&orig, &stego, None);
+        assert_eq!(score.combined_risk, DetectabilityRisk::Low);
+    }
+
+    #[test]
+    fn spectral_single_pixel_no_panic() {
+        let orig = make_spectral_cover(vec![128]);
+        let stego = make_spectral_cover(vec![129]);
+        let score = spectral_detectability_score(&orig, &stego, None);
+        assert_eq!(score.combined_risk, DetectabilityRisk::Low);
+    }
+
+    #[test]
+    fn spectral_with_ai_gen_profile_checks_carrier_bins() {
+        use crate::domain::ports::{AiGenProfile, CarrierBin};
+        // 64-element row; profile carrier bin at (0, 5) — strong.
+        let bins = vec![CarrierBin::new((0, 5), 0.0, 1.0)];
+        let mut carrier_map = HashMap::new();
+        // Key is "64x1" for width=64, height=1.
+        carrier_map.insert("64x1".to_string(), bins);
+        let profile = AiGenProfile {
+            model_id: "test-model".to_string(),
+            channel_weights: [1.0, 1.0, 1.0],
+            carrier_map,
+        };
+        let data: Vec<u8> = (0u8..64).collect();
+        let orig = make_spectral_cover(data.clone());
+        let stego = make_spectral_cover(data);
+        let score = spectral_detectability_score(&orig, &stego, Some(&profile));
+        // Identical data → low risk even with profile bins.
+        assert_eq!(score.combined_risk, DetectabilityRisk::Low);
+    }
+
+    #[test]
+    fn spectral_score_serde_round_trip() {
+        use crate::domain::types::SpectralScore;
+        let score = SpectralScore {
+            phase_coherence_drop: 0.12,
+            carrier_snr_drop_db: -0.08,
+            sample_pair_asymmetry: 0.03,
+            combined_risk: DetectabilityRisk::Medium,
+        };
+        let json = serde_json::to_string(&score).expect("serialise");
+        let back: SpectralScore = serde_json::from_str(&json).expect("deserialise");
+        assert!((back.phase_coherence_drop - score.phase_coherence_drop).abs() < 1e-10);
+        assert!((back.carrier_snr_drop_db - score.carrier_snr_drop_db).abs() < 1e-10);
+        assert_eq!(back.combined_risk, score.combined_risk);
+    }
+
+    #[test]
+    fn analysis_report_has_spectral_score_field() {
+        use crate::domain::types::{AnalysisReport, Capacity};
+        let report = AnalysisReport {
+            technique: StegoTechnique::LsbImage,
+            cover_capacity: Capacity {
+                bytes: 100,
+                technique: StegoTechnique::LsbImage,
+            },
+            chi_square_score: -13.5,
+            detectability_risk: DetectabilityRisk::Low,
+            recommended_max_payload_bytes: 50,
+            spectral_score: None,
+        };
+        assert!(report.spectral_score.is_none());
     }
 }

--- a/crates/shadowforge/src/domain/corpus/mod.rs
+++ b/crates/shadowforge/src/domain/corpus/mod.rs
@@ -115,9 +115,9 @@ pub fn filter_by_model<'a>(
     entries
         .iter()
         .filter(|e| {
-            e.spectral_key.as_ref().map_or(false, |k| {
-                k.model_id == model_id && k.resolution == resolution
-            })
+            e.spectral_key
+                .as_ref()
+                .is_some_and(|k| k.model_id == model_id && k.resolution == resolution)
         })
         .collect()
 }

--- a/crates/shadowforge/src/domain/corpus/mod.rs
+++ b/crates/shadowforge/src/domain/corpus/mod.rs
@@ -6,6 +6,8 @@
 
 use bytes::Bytes;
 
+use crate::domain::types::CorpusEntry;
+
 /// Compute the Hamming distance between two byte slices of equal length.
 ///
 /// Returns `None` if the slices differ in length.
@@ -97,6 +99,27 @@ pub const fn is_close_match(distance: u64, total_bits: u64) -> bool {
     }
     // ≤ 5% of bits differ
     distance.strict_mul(20) <= total_bits
+}
+
+/// Filter corpus entries by model ID and resolution.
+///
+/// Returns references to all entries whose `spectral_key` matches both
+/// `model_id` and `resolution`. Entries without a `spectral_key` are
+/// silently excluded.
+#[must_use]
+pub fn filter_by_model<'a>(
+    entries: &'a [CorpusEntry],
+    model_id: &str,
+    resolution: (u32, u32),
+) -> Vec<&'a CorpusEntry> {
+    entries
+        .iter()
+        .filter(|e| {
+            e.spectral_key.as_ref().map_or(false, |k| {
+                k.model_id == model_id && k.resolution == resolution
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -197,5 +220,50 @@ mod tests {
     #[test]
     fn is_close_match_zero_total() {
         assert!(!is_close_match(0, 0));
+    }
+
+    // ─── filter_by_model tests ────────────────────────────────────────────────
+
+    fn make_entry(model_id: Option<&str>, resolution: Option<(u32, u32)>) -> CorpusEntry {
+        use crate::domain::types::{CoverMediaKind, SpectralKey};
+        CorpusEntry {
+            file_hash: [0u8; 32],
+            path: "test.png".to_string(),
+            cover_kind: CoverMediaKind::PngImage,
+            precomputed_bit_pattern: Bytes::new(),
+            spectral_key: model_id.zip(resolution).map(|(id, res)| SpectralKey {
+                model_id: id.to_string(),
+                resolution: res,
+            }),
+        }
+    }
+
+    #[test]
+    fn filter_by_model_returns_matching_entries() {
+        let entries = vec![
+            make_entry(Some("gemini"), Some((1024, 1024))),
+            make_entry(Some("gemini"), Some((512, 512))),
+            make_entry(Some("other"), Some((1024, 1024))),
+            make_entry(None, None),
+        ];
+        let result = filter_by_model(&entries, "gemini", (1024, 1024));
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn filter_by_model_returns_empty_when_no_match() {
+        let entries = vec![
+            make_entry(Some("gemini"), Some((512, 512))),
+            make_entry(None, None),
+        ];
+        let result = filter_by_model(&entries, "gemini", (1024, 1024));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_by_model_excludes_no_key_entries() {
+        let entries = vec![make_entry(None, None), make_entry(None, None)];
+        let result = filter_by_model(&entries, "gemini", (1024, 1024));
+        assert!(result.is_empty());
     }
 }

--- a/crates/shadowforge/src/domain/errors.rs
+++ b/crates/shadowforge/src/domain/errors.rs
@@ -370,6 +370,14 @@ pub enum AdaptiveError {
         #[source]
         source: StegoError,
     },
+    /// The distributor returned a different number of covers than were supplied.
+    #[error("distribution cover count mismatch: got {got}, expected {expected}")]
+    DistributionCountMismatch {
+        /// Number of covers returned by the distributor.
+        got: usize,
+        /// Number of covers originally supplied.
+        expected: usize,
+    },
 }
 
 // ─── DeniableError ────────────────────────────────────────────────────────────

--- a/crates/shadowforge/src/domain/ports.rs
+++ b/crates/shadowforge/src/domain/ports.rs
@@ -391,7 +391,7 @@ pub struct CarrierBin {
 impl CarrierBin {
     /// Construct a `CarrierBin`, clamping `coherence` to `0.0..=1.0`.
     #[must_use]
-    pub fn new(freq: (u32, u32), phase: f64, coherence: f64) -> Self {
+    pub const fn new(freq: (u32, u32), phase: f64, coherence: f64) -> Self {
         Self {
             freq,
             phase,
@@ -401,7 +401,7 @@ impl CarrierBin {
 
     /// Return the (clamped) phase coherence value.
     #[must_use]
-    pub fn coherence(&self) -> f64 {
+    pub const fn coherence(&self) -> f64 {
         self.coherence
     }
 
@@ -857,13 +857,13 @@ mod cover_profile_tests {
     #[test]
     fn carrier_bin_coherence_clamped_above_one() {
         let bin = CarrierBin::new((9, 9), 0.0, 1.5);
-        assert_eq!(bin.coherence(), 1.0);
+        assert!((bin.coherence() - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]
     fn carrier_bin_coherence_clamped_below_zero() {
         let bin = CarrierBin::new((9, 9), 0.0, -0.5);
-        assert_eq!(bin.coherence(), 0.0);
+        assert!((bin.coherence() - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/shadowforge/src/domain/ports.rs
+++ b/crates/shadowforge/src/domain/ports.rs
@@ -339,12 +339,30 @@ pub trait ArchiveHandler {
 
 // ─── Adaptive Embedding ───────────────────────────────────────────────────────
 
+/// Serde helper for `[u16; 64]` — serde only auto-derives array impls up to
+/// `[T; 32]`, so we provide a thin wrapper using `Vec<u16>` as the wire format.
+mod serde_quant_table {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(arr: &[u16; 64], s: S) -> Result<S::Ok, S::Error> {
+        arr.as_slice().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u16; 64], D::Error> {
+        let v = Vec::<u16>::deserialize(d)?;
+        v.as_slice().try_into().map_err(|_| {
+            serde::de::Error::invalid_length(v.len(), &"exactly 64 JPEG quantisation coefficients")
+        })
+    }
+}
+
 /// Camera-model statistical fingerprint — used to defeat model-based
 /// steganalysis by matching the cover's noise floor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CameraProfile {
     /// JPEG quantisation table (64 coefficients in zig-zag order).
-    pub quantisation_table: Vec<u16>,
+    #[serde(with = "serde_quant_table")]
+    pub quantisation_table: [u16; 64],
     /// Estimated noise floor of the camera sensor (in decibels).
     pub noise_floor_db: f64,
     /// Human-readable camera model identifier.
@@ -384,8 +402,16 @@ pub struct CarrierBin {
     /// Expected phase angle of the carrier (radians).
     pub phase: f64,
     /// Measured phase coherence across reference images, clamped to
-    /// `0.0..=1.0` by the constructor.
+    /// `0.0..=1.0` by the constructor.  The custom deserializer enforces
+    /// the same clamp so untrusted profiles cannot bypass it.
+    #[serde(deserialize_with = "de_clamp_coherence")]
     coherence: f64,
+}
+
+/// Serde deserializer that clamps a `f64` to `0.0..=1.0`.
+fn de_clamp_coherence<'de, D: serde::Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let v = f64::deserialize(d)?;
+    Ok(v.clamp(0.0, 1.0))
 }
 
 impl CarrierBin {
@@ -837,7 +863,7 @@ mod cover_profile_tests {
     #[test]
     fn camera_profile_model_id_via_cover_profile() {
         let profile = CoverProfile::Camera(CameraProfile {
-            quantisation_table: vec![0u16; 64],
+            quantisation_table: [0u16; 64],
             noise_floor_db: -80.0,
             model_id: "canon-eos-r6".to_string(),
         });
@@ -927,7 +953,7 @@ mod cover_profile_tests {
     #[test]
     fn camera_cover_profile_round_trips_through_serde_json() -> TestResult {
         let profile = CoverProfile::Camera(CameraProfile {
-            quantisation_table: vec![2u16; 64],
+            quantisation_table: [2u16; 64],
             noise_floor_db: -75.0,
             model_id: "nikon-z9".to_string(),
         });

--- a/crates/shadowforge/src/domain/ports.rs
+++ b/crates/shadowforge/src/domain/ports.rs
@@ -5,11 +5,13 @@
 //! assertions below. No I/O, no `async`, no concrete types from external
 //! crates appear in return positions.
 
+use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::Path;
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use crate::domain::errors::{
     AdaptiveError, AnalysisError, ArchiveError, CanaryError, CorrectionError, CryptoError,
@@ -339,14 +341,100 @@ pub trait ArchiveHandler {
 
 /// Camera-model statistical fingerprint — used to defeat model-based
 /// steganalysis by matching the cover's noise floor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CameraProfile {
     /// JPEG quantisation table (64 coefficients in zig-zag order).
-    pub quantisation_table: [u16; 64],
+    pub quantisation_table: Vec<u16>,
     /// Estimated noise floor of the camera sensor (in decibels).
     pub noise_floor_db: f64,
     /// Human-readable camera model identifier.
     pub model_id: String,
+}
+
+/// Spectral fingerprint for a single AI image generator model.
+///
+/// Stores per-resolution carrier frequency maps extracted from reference
+/// images (pure-black / pure-white outputs dominated by the watermark
+/// signal).  The `carrier_map` key is `"WIDTHxHEIGHT"` (e.g. `"1024x1024"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiGenProfile {
+    /// Generator identifier, e.g. `"gemini"`, `"midjourney-v7"`.
+    pub model_id: String,
+    /// Per-channel embedding weights `[R, G, B]` (G is reference=1.0).
+    pub channel_weights: [f64; 3],
+    /// Map from `"WxH"` resolution string to carrier bin list.
+    pub carrier_map: HashMap<String, Vec<CarrierBin>>,
+}
+
+impl AiGenProfile {
+    /// Return carrier bins for the given resolution, or `None` if unknown.
+    #[must_use]
+    pub fn carrier_bins_for(&self, width: u32, height: u32) -> Option<&[CarrierBin]> {
+        let key = format!("{width}x{height}");
+        self.carrier_map.get(&key).map(Vec::as_slice)
+    }
+}
+
+/// A single frequency-domain carrier bin occupied by an AI generator's
+/// watermark.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CarrierBin {
+    /// `(row_bin, col_bin)` in the 2-D FFT of the green channel.
+    pub freq: (u32, u32),
+    /// Expected phase angle of the carrier (radians).
+    pub phase: f64,
+    /// Measured phase coherence across reference images, clamped to
+    /// `0.0..=1.0` by the constructor.
+    coherence: f64,
+}
+
+impl CarrierBin {
+    /// Construct a `CarrierBin`, clamping `coherence` to `0.0..=1.0`.
+    #[must_use]
+    pub fn new(freq: (u32, u32), phase: f64, coherence: f64) -> Self {
+        Self {
+            freq,
+            phase,
+            coherence: coherence.clamp(0.0, 1.0),
+        }
+    }
+
+    /// Return the (clamped) phase coherence value.
+    #[must_use]
+    pub fn coherence(&self) -> f64 {
+        self.coherence
+    }
+
+    /// Return `true` when coherence ≥ 0.90 — a reliable carrier.
+    #[must_use]
+    pub fn is_strong(&self) -> bool {
+        self.coherence >= 0.90
+    }
+}
+
+/// Discriminated union of cover-source fingerprint profiles.
+///
+/// Use `CoverProfile::Camera` for traditional camera-sourced images and
+/// `CoverProfile::AiGenerator` for AI-generated covers (Gemini, Midjourney,
+/// etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data")]
+pub enum CoverProfile {
+    /// Traditional camera-sourced image (JPEG quant table + sensor noise).
+    Camera(CameraProfile),
+    /// AI-generated image with per-resolution spectral carrier bins.
+    AiGenerator(AiGenProfile),
+}
+
+impl CoverProfile {
+    /// Return the human-readable generator / camera model identifier.
+    #[must_use]
+    pub fn model_id(&self) -> &str {
+        match self {
+            Self::Camera(p) => &p.model_id,
+            Self::AiGenerator(p) => &p.model_id,
+        }
+    }
 }
 
 /// Adversarial embedding optimiser port (STC-inspired).
@@ -368,21 +456,22 @@ pub trait AdaptiveOptimiser {
     ) -> Result<CoverMedia, AdaptiveError>;
 }
 
-/// Camera model fingerprint matching port.
+/// Cover profile matching port — detects whether a cover is AI-generated or
+/// camera-sourced.
 pub trait CoverProfileMatcher {
-    /// Return the best-matching [`CameraProfile`] for `cover`, or `None`
+    /// Return the best-matching [`CoverProfile`] for `cover`, or `None`
     /// if no profile is close enough.
-    fn profile_for(&self, cover: &CoverMedia) -> Option<CameraProfile>;
+    fn profile_for(&self, cover: &CoverMedia) -> Option<CoverProfile>;
 
-    /// Apply `profile` to `cover` to make it statistically match that
-    /// camera model.
+    /// Apply `profile` to `cover` (e.g. adjust JPEG quant tables for a
+    /// camera profile; no-op for AI profiles — we avoid their bins instead).
     ///
     /// # Errors
     /// Returns [`AdaptiveError::ProfileMatchFailed`].
     fn apply_profile(
         &self,
         cover: CoverMedia,
-        profile: &CameraProfile,
+        profile: &CoverProfile,
     ) -> Result<CoverMedia, AdaptiveError>;
 }
 
@@ -670,6 +759,29 @@ pub trait CorpusIndex {
     /// # Errors
     /// Returns [`crate::domain::errors::CorpusError::IndexError`].
     fn build_index(&self, corpus_dir: &Path) -> Result<usize, crate::domain::errors::CorpusError>;
+
+    /// Search the index for covers that match `payload` and have a
+    /// `spectral_key` whose `model_id` and `resolution` match the supplied
+    /// values.
+    ///
+    /// Returns up to `max_results` entries sorted by match quality.
+    ///
+    /// # Errors
+    /// Returns [`crate::domain::errors::CorpusError::NoSuitableCover`] or
+    /// [`crate::domain::errors::CorpusError::IndexError`].
+    fn search_for_model(
+        &self,
+        payload: &Payload,
+        model_id: &str,
+        resolution: (u32, u32),
+        max_results: usize,
+    ) -> Result<Vec<crate::domain::types::CorpusEntry>, crate::domain::errors::CorpusError>;
+
+    /// Return a sorted list of `(SpectralKey, count)` pairs describing how
+    /// many corpus entries are indexed per model/resolution combination.
+    ///
+    /// Using `Vec` instead of `HashMap` to keep the trait object-safe.
+    fn model_stats(&self) -> Vec<(crate::domain::types::SpectralKey, usize)>;
 }
 
 // ─── Object-Safety Assertions ─────────────────────────────────────────────────
@@ -713,5 +825,115 @@ mod object_safety_tests {
         assert_object_safe::<dyn TimeLockService>();
         assert_object_safe::<dyn StyloScrubber>();
         assert_object_safe::<dyn CorpusIndex>();
+    }
+}
+
+#[cfg(test)]
+mod cover_profile_tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn camera_profile_model_id_via_cover_profile() {
+        let profile = CoverProfile::Camera(CameraProfile {
+            quantisation_table: vec![0u16; 64],
+            noise_floor_db: -80.0,
+            model_id: "canon-eos-r6".to_string(),
+        });
+        assert_eq!(profile.model_id(), "canon-eos-r6");
+    }
+
+    #[test]
+    fn ai_gen_profile_model_id_via_cover_profile() {
+        let profile = CoverProfile::AiGenerator(AiGenProfile {
+            model_id: "gemini".to_string(),
+            channel_weights: [0.85, 1.0, 0.70],
+            carrier_map: HashMap::new(),
+        });
+        assert_eq!(profile.model_id(), "gemini");
+    }
+
+    #[test]
+    fn carrier_bin_coherence_clamped_above_one() {
+        let bin = CarrierBin::new((9, 9), 0.0, 1.5);
+        assert_eq!(bin.coherence(), 1.0);
+    }
+
+    #[test]
+    fn carrier_bin_coherence_clamped_below_zero() {
+        let bin = CarrierBin::new((9, 9), 0.0, -0.5);
+        assert_eq!(bin.coherence(), 0.0);
+    }
+
+    #[test]
+    fn carrier_bin_is_strong_at_exactly_0_90() {
+        let strong = CarrierBin::new((9, 9), 0.0, 0.90);
+        assert!(strong.is_strong());
+    }
+
+    #[test]
+    fn carrier_bin_not_strong_below_0_90() {
+        let weak = CarrierBin::new((9, 9), 0.0, 0.899_999);
+        assert!(!weak.is_strong());
+    }
+
+    #[test]
+    fn ai_gen_profile_carrier_bins_for_known_resolution() {
+        let bins = vec![CarrierBin::new((9, 9), 0.0, 1.0)];
+        let mut carrier_map = HashMap::new();
+        carrier_map.insert("1024x1024".to_string(), bins);
+        let profile = AiGenProfile {
+            model_id: "gemini".to_string(),
+            channel_weights: [0.85, 1.0, 0.70],
+            carrier_map,
+        };
+        assert!(profile.carrier_bins_for(1024, 1024).is_some());
+        assert!(profile.carrier_bins_for(512, 512).is_none());
+    }
+
+    #[test]
+    fn ai_gen_profile_carrier_bins_count() {
+        let bins = vec![
+            CarrierBin::new((9, 9), 0.0, 1.0),
+            CarrierBin::new((5, 5), 0.0, 1.0),
+        ];
+        let mut carrier_map = HashMap::new();
+        carrier_map.insert("1024x1024".to_string(), bins);
+        let profile = AiGenProfile {
+            model_id: "gemini".to_string(),
+            channel_weights: [0.85, 1.0, 0.70],
+            carrier_map,
+        };
+        assert_eq!(
+            profile.carrier_bins_for(1024, 1024).map(<[_]>::len),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn cover_profile_round_trips_through_serde_json() -> TestResult {
+        let profile = CoverProfile::AiGenerator(AiGenProfile {
+            model_id: "gemini".to_string(),
+            channel_weights: [0.85, 1.0, 0.70],
+            carrier_map: HashMap::new(),
+        });
+        let json = serde_json::to_string(&profile)?;
+        let decoded: CoverProfile = serde_json::from_str(&json)?;
+        assert_eq!(decoded.model_id(), "gemini");
+        Ok(())
+    }
+
+    #[test]
+    fn camera_cover_profile_round_trips_through_serde_json() -> TestResult {
+        let profile = CoverProfile::Camera(CameraProfile {
+            quantisation_table: vec![2u16; 64],
+            noise_floor_db: -75.0,
+            model_id: "nikon-z9".to_string(),
+        });
+        let json = serde_json::to_string(&profile)?;
+        let decoded: CoverProfile = serde_json::from_str(&json)?;
+        assert_eq!(decoded.model_id(), "nikon-z9");
+        Ok(())
     }
 }

--- a/crates/shadowforge/src/domain/types.rs
+++ b/crates/shadowforge/src/domain/types.rs
@@ -1046,15 +1046,11 @@ mod tests {
         // The default adaptive profile must encode the canonical threshold so
         // the runner never hard-codes a magic number.
         let profile = EmbeddingProfile::default_adaptive();
-        let EmbeddingProfile::Adaptive { max_detectability_db } = profile else {
-            panic!("expected Adaptive variant");
-        };
-        #[expect(clippy::float_cmp)]
-        {
-            assert!(
-                (max_detectability_db - DEFAULT_ADAPTIVE_DETECTABILITY_DB).abs() < f64::EPSILON,
-                "expected {DEFAULT_ADAPTIVE_DETECTABILITY_DB}, got {max_detectability_db}"
-            );
-        }
+        assert!(matches!(
+            profile,
+            EmbeddingProfile::Adaptive {
+                max_detectability_db
+            } if (max_detectability_db - DEFAULT_ADAPTIVE_DETECTABILITY_DB).abs() < f64::EPSILON
+        ));
     }
 }

--- a/crates/shadowforge/src/domain/types.rs
+++ b/crates/shadowforge/src/domain/types.rs
@@ -360,6 +360,23 @@ pub enum DetectabilityRisk {
 
 // ─── AnalysisReport ───────────────────────────────────────────────────────────
 
+/// Spectral-domain detectability metrics comparing an original cover to a
+/// stego image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpectralScore {
+    /// Drop in normalised phase coherence at carrier bins, 0.0–1.0.
+    /// 0.0 = no disruption; 1.0 = complete decoherence.
+    pub phase_coherence_drop: f64,
+    /// Mean SNR drop at carrier bins in dB.  Negative = energy removed
+    /// (less detectable); positive = energy added (more detectable).
+    pub carrier_snr_drop_db: f64,
+    /// Adjacent pixel-pair parity asymmetry, 0.0–1.0.
+    /// 0.0 = balanced pairs; higher = LSB bias in cover.
+    pub sample_pair_asymmetry: f64,
+    /// Qualitative combined risk classification.
+    pub combined_risk: DetectabilityRisk,
+}
+
 /// Steganalysis report for a cover medium.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnalysisReport {
@@ -373,6 +390,9 @@ pub struct AnalysisReport {
     pub detectability_risk: DetectabilityRisk,
     /// Conservative payload size that stays below the detectability threshold.
     pub recommended_max_payload_bytes: u64,
+    /// Spectral-domain score, populated when `spectral_detectability_score`
+    /// is called.  `None` when only the basic chi-square analysis was run.
+    pub spectral_score: Option<SpectralScore>,
 }
 
 // ─── WatermarkReceipt ─────────────────────────────────────────────────────────
@@ -531,7 +551,20 @@ pub struct TimeLockPuzzle {
     pub unlock_at: DateTime<Utc>,
 }
 
-// ─── CorpusEntry ──────────────────────────────────────────────────────────────
+// ─── SpectralKey ────────────────────────────────────────────────────────
+
+/// Spectral fingerprint key for model-aware corpus indexing.
+///
+/// Used as a `HashMap` key so all four standard traits are derived.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SpectralKey {
+    /// Generator model identifier (e.g. `"gemini"`, `"midjourney-v7"`).
+    pub model_id: String,
+    /// Image resolution `(width, height)` matching this profile.
+    pub resolution: (u32, u32),
+}
+
+// ─── CorpusEntry ────────────────────────────────────────────────────────
 
 /// An indexed entry in a local image corpus for zero-modification stego.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -544,6 +577,9 @@ pub struct CorpusEntry {
     pub cover_kind: CoverMediaKind,
     /// Precomputed LSB bit pattern for ANN matching.
     pub precomputed_bit_pattern: Bytes,
+    /// Optional spectral profile key — set when this is an AI-generated image
+    /// identified by [`crate::domain::ports::CoverProfileMatcher`].
+    pub spectral_key: Option<SpectralKey>,
 }
 
 // ─── StyloProfile ─────────────────────────────────────────────────────────────
@@ -750,6 +786,7 @@ mod tests {
             chi_square_score: 0.42,
             detectability_risk: DetectabilityRisk::Low,
             recommended_max_payload_bytes: 512,
+            spectral_score: None,
         };
         let json = serde_json::to_string(&report)?;
         assert!(json.contains("DctJpeg"));
@@ -875,6 +912,7 @@ mod tests {
             path: "images/cover.png".into(),
             cover_kind: CoverMediaKind::PngImage,
             precomputed_bit_pattern: Bytes::from(vec![0u8; 16]),
+            spectral_key: None,
         };
         let json = serde_json::to_string(&entry)?;
         assert!(json.contains("images/cover.png"));
@@ -925,5 +963,63 @@ mod tests {
         };
         let dbg = format!("{config:?}");
         assert!(dbg.contains("key_paths"));
+    }
+
+    #[test]
+    fn spectral_key_round_trips_through_serde_json() -> TestResult {
+        let key = SpectralKey {
+            model_id: "gemini".to_string(),
+            resolution: (1024, 1024),
+        };
+        let json = serde_json::to_string(&key)?;
+        let decoded: SpectralKey = serde_json::from_str(&json)?;
+        assert_eq!(decoded.model_id, "gemini");
+        assert_eq!(decoded.resolution, (1024, 1024));
+        Ok(())
+    }
+
+    #[test]
+    fn spectral_key_usable_as_hashmap_key() {
+        let mut map = std::collections::HashMap::new();
+        let key = SpectralKey {
+            model_id: "gemini".to_string(),
+            resolution: (1024, 1024),
+        };
+        map.insert(key.clone(), 42usize);
+        assert_eq!(map.get(&key), Some(&42));
+    }
+
+    #[test]
+    fn corpus_entry_with_spectral_key_serialises() -> TestResult {
+        let entry = CorpusEntry {
+            file_hash: [0xCC; 32],
+            path: "ai/image.png".into(),
+            cover_kind: CoverMediaKind::PngImage,
+            precomputed_bit_pattern: Bytes::from(vec![0u8; 8]),
+            spectral_key: Some(SpectralKey {
+                model_id: "gemini".to_string(),
+                resolution: (1024, 1024),
+            }),
+        };
+        let json = serde_json::to_string(&entry)?;
+        assert!(json.contains("gemini"));
+        let decoded: CorpusEntry = serde_json::from_str(&json)?;
+        assert!(decoded.spectral_key.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn corpus_entry_without_spectral_key_serialises() -> TestResult {
+        let entry = CorpusEntry {
+            file_hash: [0xDD; 32],
+            path: "camera/photo.jpg".into(),
+            cover_kind: CoverMediaKind::JpegImage,
+            precomputed_bit_pattern: Bytes::from(vec![0u8; 8]),
+            spectral_key: None,
+        };
+        let json = serde_json::to_string(&entry)?;
+        let decoded: CorpusEntry = serde_json::from_str(&json)?;
+        assert!(decoded.spectral_key.is_none());
+        Ok(())
     }
 }

--- a/crates/shadowforge/src/domain/types.rs
+++ b/crates/shadowforge/src/domain/types.rs
@@ -190,6 +190,24 @@ pub enum EmbeddingProfile {
     CorpusBased,
 }
 
+/// Maximum detectability budget (dB) used when no explicit value is configured.
+///
+/// Chosen as a conservative threshold that balances stealth and payload
+/// capacity.  A negative value means the stego cover must have *lower* spectral
+/// energy than the original.
+pub const DEFAULT_ADAPTIVE_DETECTABILITY_DB: f64 = -12.0;
+
+impl EmbeddingProfile {
+    /// Return the standard adaptive profile with the default detectability
+    /// budget ([`DEFAULT_ADAPTIVE_DETECTABILITY_DB`]).
+    #[must_use]
+    pub const fn default_adaptive() -> Self {
+        Self::Adaptive {
+            max_detectability_db: DEFAULT_ADAPTIVE_DETECTABILITY_DB,
+        }
+    }
+}
+
 // ─── DistributionPattern ──────────────────────────────────────────────────────
 
 /// How payload shards are distributed across carriers.
@@ -1021,5 +1039,22 @@ mod tests {
         let decoded: CorpusEntry = serde_json::from_str(&json)?;
         assert!(decoded.spectral_key.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn default_adaptive_uses_named_constant() {
+        // The default adaptive profile must encode the canonical threshold so
+        // the runner never hard-codes a magic number.
+        let profile = EmbeddingProfile::default_adaptive();
+        let EmbeddingProfile::Adaptive { max_detectability_db } = profile else {
+            panic!("expected Adaptive variant");
+        };
+        #[expect(clippy::float_cmp)]
+        {
+            assert!(
+                (max_detectability_db - DEFAULT_ADAPTIVE_DETECTABILITY_DB).abs() < f64::EPSILON,
+                "expected {DEFAULT_ADAPTIVE_DETECTABILITY_DB}, got {max_detectability_db}"
+            );
+        }
     }
 }

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -483,7 +483,7 @@ pub enum CorpusSubcommand {
         /// Restrict search to covers matching this AI model ID (e.g. "gemini").
         #[arg(long)]
         model: Option<String>,
-        /// Cover resolution to match when `--model` is set, in WIDTHxHEIGHT
+        /// Cover resolution to match when `--model` is set, in `WIDTHxHEIGHT`
         /// format (e.g. "1024x1024").  Ignored if `--model` is absent.
         #[arg(long)]
         resolution: Option<String>,

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -480,6 +480,13 @@ pub enum CorpusSubcommand {
         /// Maximum results to return.
         #[arg(long, default_value = "5")]
         top: usize,
+        /// Restrict search to covers matching this AI model ID (e.g. "gemini").
+        #[arg(long)]
+        model: Option<String>,
+        /// Cover resolution to match when `--model` is set, in WIDTHxHEIGHT
+        /// format (e.g. "1024x1024").  Ignored if `--model` is absent.
+        #[arg(long)]
+        resolution: Option<String>,
     },
 }
 

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -73,6 +73,9 @@ pub enum Commands {
 
     /// Generate shell completions.
     Completions(CompletionsArgs),
+
+    /// Symmetric cipher operations (AES-256-GCM).
+    Cipher(CipherArgs),
 }
 
 // ─── Value enums ──────────────────────────────────────────────────────────────
@@ -510,6 +513,45 @@ pub struct CompletionsArgs {
     pub output: Option<PathBuf>,
 }
 
+/// Arguments for `cipher`.
+#[derive(Parser, Debug)]
+pub struct CipherArgs {
+    /// Cipher sub-operation.
+    #[command(subcommand)]
+    pub subcmd: CipherSubcommand,
+}
+
+/// Cipher sub-operations.
+#[derive(Subcommand, Debug)]
+pub enum CipherSubcommand {
+    /// Encrypt a file with AES-256-GCM. A random 12-byte nonce is generated and
+    /// prepended to the output ciphertext.
+    Encrypt {
+        /// Input plaintext file.
+        #[arg(long)]
+        input: PathBuf,
+        /// 32-byte key file.
+        #[arg(long)]
+        key: PathBuf,
+        /// Output file (nonce ‖ ciphertext).
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Decrypt a file encrypted with AES-256-GCM. The nonce is read from the
+    /// first 12 bytes of the input file.
+    Decrypt {
+        /// Input ciphertext file (12-byte nonce in first bytes).
+        #[arg(long)]
+        input: PathBuf,
+        /// 32-byte key file.
+        #[arg(long)]
+        key: PathBuf,
+        /// Output plaintext file.
+        #[arg(long)]
+        output: PathBuf,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -642,5 +684,37 @@ mod tests {
     fn version_output_contains_semver() {
         let version = env!("CARGO_PKG_VERSION");
         assert!(version.contains('.'), "version should be semver");
+    }
+
+    #[test]
+    fn cli_parse_cipher_encrypt() {
+        let cli = Cli::try_parse_from([
+            "shadowforge",
+            "cipher",
+            "encrypt",
+            "--input",
+            "payload.bin",
+            "--key",
+            "key.bin",
+            "--output",
+            "out.enc",
+        ]);
+        assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn cli_parse_cipher_decrypt() {
+        let cli = Cli::try_parse_from([
+            "shadowforge",
+            "cipher",
+            "decrypt",
+            "--input",
+            "out.enc",
+            "--key",
+            "key.bin",
+            "--output",
+            "recovered.bin",
+        ]);
+        assert!(cli.is_ok());
     }
 }

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -26,7 +26,7 @@ pub enum Commands {
     /// Print version and git SHA.
     Version,
 
-    /// Generate a key pair.
+    /// Key generation and signing operations.
     Keygen(KeygenArgs),
 
     /// Embed a payload into a cover medium.
@@ -161,12 +161,44 @@ pub enum ArchiveFormat {
 /// Arguments for `keygen`.
 #[derive(Parser, Debug)]
 pub struct KeygenArgs {
+    /// Keygen sub-operation.
+    #[command(subcommand)]
+    pub subcmd: Option<KeygenSubcommand>,
     /// Algorithm to use.
     #[arg(long, value_enum)]
-    pub algorithm: Algorithm,
+    pub algorithm: Option<Algorithm>,
     /// Output directory for key files.
     #[arg(long)]
-    pub output: PathBuf,
+    pub output: Option<PathBuf>,
+}
+
+/// `keygen` sub-operations.
+#[derive(Subcommand, Debug)]
+pub enum KeygenSubcommand {
+    /// Sign an input file with an ML-DSA secret key.
+    Sign {
+        /// Input file to sign.
+        #[arg(long)]
+        input: PathBuf,
+        /// Secret signing key file.
+        #[arg(long)]
+        secret_key: PathBuf,
+        /// Output detached signature file.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Verify a detached signature with an ML-DSA public key.
+    Verify {
+        /// Signed input file.
+        #[arg(long)]
+        input: PathBuf,
+        /// Public verification key file.
+        #[arg(long)]
+        public_key: PathBuf,
+        /// Detached signature file.
+        #[arg(long)]
+        signature: PathBuf,
+    },
 }
 
 /// Arguments for `embed`.
@@ -571,6 +603,38 @@ mod tests {
             "kyber1024",
             "--output",
             "/tmp/keys",
+        ]);
+        assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn cli_parse_keygen_sign() {
+        let cli = Cli::try_parse_from([
+            "shadowforge",
+            "keygen",
+            "sign",
+            "--input",
+            "payload.bin",
+            "--secret-key",
+            "secret.key",
+            "--output",
+            "payload.sig",
+        ]);
+        assert!(cli.is_ok());
+    }
+
+    #[test]
+    fn cli_parse_keygen_verify() {
+        let cli = Cli::try_parse_from([
+            "shadowforge",
+            "keygen",
+            "verify",
+            "--input",
+            "payload.bin",
+            "--public-key",
+            "public.key",
+            "--signature",
+            "payload.sig",
         ]);
         assert!(cli.is_ok());
     }

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -14,7 +14,7 @@ use crate::application::services::{
 };
 use crate::domain::errors::{CanaryError, OpsecError, StegoError};
 use crate::domain::ports::{EmbedTechnique, ExtractTechnique, GeographicDistributor, MediaLoader};
-use crate::domain::types::{CoverMedia, CoverMediaKind, Payload, StegoTechnique};
+use crate::domain::types::{CoverMedia, CoverMediaKind, Payload, Signature, StegoTechnique};
 
 use super::cli::{self, Cli, Commands};
 
@@ -64,10 +64,36 @@ fn print_version() {
 // ─── Keygen ───────────────────────────────────────────────────────────────────
 
 fn cmd_keygen(args: &cli::KeygenArgs) -> Result<(), AppError> {
-    let dir = &args.output;
+    match &args.subcmd {
+        Some(cli::KeygenSubcommand::Sign {
+            input,
+            secret_key,
+            output,
+        }) => cmd_keygen_sign(input, secret_key, output),
+        Some(cli::KeygenSubcommand::Verify {
+            input,
+            public_key,
+            signature,
+        }) => cmd_keygen_verify(input, public_key, signature),
+        None => cmd_keygen_generate(args),
+    }
+}
+
+fn cmd_keygen_generate(args: &cli::KeygenArgs) -> Result<(), AppError> {
+    let Some(dir) = args.output.as_ref() else {
+        return Err(AppError::Stego(StegoError::MalformedCoverData {
+            reason: "--output is required when no keygen subcommand is used".to_string(),
+        }));
+    };
+    let Some(algorithm) = args.algorithm else {
+        return Err(AppError::Stego(StegoError::MalformedCoverData {
+            reason: "--algorithm is required when no keygen subcommand is used".to_string(),
+        }));
+    };
+
     fs_create_dir_all(dir)?;
 
-    match args.algorithm {
+    match algorithm {
         cli::Algorithm::Kyber1024 => {
             let enc = crate::adapters::crypto::MlKemEncryptor;
             let kp = KeyGenService::generate_keypair(&enc)?;
@@ -83,6 +109,34 @@ fn cmd_keygen(args: &cli::KeygenArgs) -> Result<(), AppError> {
     }
     eprintln!("Keys written to {}", dir.display());
     Ok(())
+}
+
+fn cmd_keygen_sign(input: &Path, secret_key: &Path, output: &Path) -> Result<(), AppError> {
+    let signer = crate::adapters::crypto::MlDsaSigner;
+    let message = fs_read(input)?;
+    let sk = fs_read(secret_key)?;
+    let signature = KeyGenService::sign(&signer, &sk, &message)?;
+    fs_write(output, signature.0.as_ref())?;
+    eprintln!("Signature written to {}", output.display());
+    Ok(())
+}
+
+fn cmd_keygen_verify(input: &Path, public_key: &Path, signature: &Path) -> Result<(), AppError> {
+    let signer = crate::adapters::crypto::MlDsaSigner;
+    let message = fs_read(input)?;
+    let pk = fs_read(public_key)?;
+    let sig = Signature(bytes::Bytes::from(fs_read(signature)?));
+    let valid = KeyGenService::verify(&signer, &pk, &message, &sig)?;
+    if valid {
+        eprintln!("Signature verification: ok");
+        Ok(())
+    } else {
+        Err(AppError::Crypto(
+            crate::domain::errors::CryptoError::VerificationFailed {
+                reason: "invalid signature".to_string(),
+            },
+        ))
+    }
 }
 
 // ─── Embed ────────────────────────────────────────────────────────────────────
@@ -1335,10 +1389,11 @@ fn load_watermark_tags(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_embedder, build_extractor, cmd_extract, load_cover, load_cover_from_path,
+        build_embedder, build_extractor, cmd_extract, cmd_keygen, load_cover, load_cover_from_path,
         save_cover_to_path,
     };
-    use crate::application::services::DeniableEmbedService;
+    use crate::application::services::{AppError, DeniableEmbedService};
+    use crate::domain::errors::CryptoError;
     use crate::domain::types::{CoverMediaKind, StegoTechnique};
     use crate::interface::cli;
     use image::{DynamicImage, Rgba, RgbaImage};
@@ -1439,6 +1494,94 @@ mod tests {
 
         let extracted = fs::read(output_path)?;
         assert_eq!(extracted, b"real secret");
+        Ok(())
+    }
+
+    #[test]
+    fn keygen_sign_produces_signature_artifact() -> TestResult {
+        let dir = tempdir()?;
+        let keys_dir = dir.path().join("keys");
+        let msg_path = dir.path().join("message.bin");
+        let sig_path = dir.path().join("message.sig");
+
+        let generate = cli::KeygenArgs {
+            subcmd: None,
+            algorithm: Some(cli::Algorithm::Dilithium3),
+            output: Some(keys_dir.clone()),
+        };
+        cmd_keygen(&generate)?;
+
+        fs::write(&msg_path, b"hello signer")?;
+        let sign = cli::KeygenArgs {
+            subcmd: Some(cli::KeygenSubcommand::Sign {
+                input: msg_path,
+                secret_key: keys_dir.join("secret.key"),
+                output: sig_path.clone(),
+            }),
+            algorithm: None,
+            output: None,
+        };
+        cmd_keygen(&sign)?;
+
+        let sig = fs::read(sig_path)?;
+        assert!(!sig.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn keygen_verify_reports_success_and_failure_status() -> TestResult {
+        let dir = tempdir()?;
+        let keys_dir = dir.path().join("keys");
+        let msg_path = dir.path().join("message.bin");
+        let tampered_path = dir.path().join("message_tampered.bin");
+        let sig_path = dir.path().join("message.sig");
+
+        let generate = cli::KeygenArgs {
+            subcmd: None,
+            algorithm: Some(cli::Algorithm::Dilithium3),
+            output: Some(keys_dir.clone()),
+        };
+        cmd_keygen(&generate)?;
+
+        fs::write(&msg_path, b"signed message")?;
+        fs::write(&tampered_path, b"signed message with tamper")?;
+
+        let sign = cli::KeygenArgs {
+            subcmd: Some(cli::KeygenSubcommand::Sign {
+                input: msg_path.clone(),
+                secret_key: keys_dir.join("secret.key"),
+                output: sig_path.clone(),
+            }),
+            algorithm: None,
+            output: None,
+        };
+        cmd_keygen(&sign)?;
+
+        let verify_ok = cli::KeygenArgs {
+            subcmd: Some(cli::KeygenSubcommand::Verify {
+                input: msg_path,
+                public_key: keys_dir.join("public.key"),
+                signature: sig_path.clone(),
+            }),
+            algorithm: None,
+            output: None,
+        };
+        assert!(cmd_keygen(&verify_ok).is_ok());
+
+        let verify_fail = cli::KeygenArgs {
+            subcmd: Some(cli::KeygenSubcommand::Verify {
+                input: tampered_path,
+                public_key: keys_dir.join("public.key"),
+                signature: sig_path,
+            }),
+            algorithm: None,
+            output: None,
+        };
+        let err = cmd_keygen(&verify_fail).err();
+        assert!(matches!(
+            err,
+            Some(AppError::Crypto(CryptoError::VerificationFailed { .. }))
+        ));
         Ok(())
     }
 

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -354,8 +354,7 @@ fn distribute_covers(
         args.data_shards,
         args.parity_shards,
     );
-    let (matcher, optimiser, compressor) =
-        crate::adapters::adaptive::build_adaptive_profile_deps();
+    let (matcher, optimiser, compressor) = crate::adapters::adaptive::build_adaptive_profile_deps();
 
     let stego_covers =
         crate::application::services::DistributeService::distribute_with_profile_hardening(
@@ -1457,7 +1456,7 @@ mod tests {
                 bytes: 1024,
                 technique: ST::LsbImage,
             },
-            chi_square_score: 3.14,
+            chi_square_score: std::f64::consts::PI,
             detectability_risk: DetectabilityRisk::Low,
             recommended_max_payload_bytes: 512,
             spectral_score: None,

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -13,7 +13,7 @@ use crate::application::services::{
     ExtractService, KeyGenService, ScrubService,
 };
 use crate::domain::errors::{CanaryError, OpsecError, StegoError};
-use crate::domain::ports::{EmbedTechnique, ExtractTechnique, GeographicDistributor, MediaLoader};
+use crate::domain::ports::{EmbedTechnique, ExtractTechnique, MediaLoader};
 use crate::domain::types::{CoverMedia, CoverMediaKind, Payload, Signature, StegoTechnique};
 
 use super::cli::{self, Cli, Commands};
@@ -389,7 +389,13 @@ fn distribute_covers(
         let manifest = load_geographic_manifest(manifest_path)?;
         let geo_distributor = crate::adapters::opsec::GeographicDistributorImpl::new();
         let stego_covers =
-            geo_distributor.distribute_with_manifest(payload, covers, &manifest, embedder)?;
+            crate::application::services::DistributeService::distribute_with_geographic_manifest(
+                payload,
+                covers,
+                &manifest,
+                embedder,
+                &geo_distributor,
+            )?;
         return Ok((stego_covers, None));
     }
 

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -9,8 +9,8 @@ const MAX_STDIN_PAYLOAD: u64 = 256 * 1024 * 1024;
 use clap::Parser;
 
 use crate::application::services::{
-    AnalyseService, AppError, ArchiveService, CipherService, EmbedService, ExtractService,
-    KeyGenService, ScrubService,
+    AnalyseService, AppError, ArchiveService, CipherService, CorpusService, EmbedService,
+    ExtractService, KeyGenService, ScrubService,
 };
 use crate::domain::errors::{CanaryError, OpsecError, StegoError};
 use crate::domain::ports::{EmbedTechnique, ExtractTechnique, GeographicDistributor, MediaLoader};
@@ -675,12 +675,10 @@ fn cmd_watermark(args: &cli::WatermarkArgs) -> Result<(), AppError> {
 // ─── Corpus ───────────────────────────────────────────────────────────────────
 
 fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
-    use crate::domain::ports::CorpusIndex;
-
     let index = crate::adapters::corpus::CorpusIndexImpl::new();
     match &args.subcmd {
         cli::CorpusSubcommand::Build { dir } => {
-            let count = index.build_index(dir)?;
+            let count = CorpusService::build_index(&index, dir)?;
             eprintln!("Indexed {count} images from {}", dir.display());
         }
         cli::CorpusSubcommand::Search {
@@ -705,9 +703,9 @@ fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
                         Some((w, h))
                     })
                     .unwrap_or((0, 0));
-                index.search_for_model(&payload, model_id, res, *top)?
+                CorpusService::search_for_model(&index, &payload, model_id, res, *top)?
             } else {
-                index.search(&payload, tech, *top)?
+                CorpusService::search(&index, &payload, tech, *top)?
             };
 
             for entry in &results {

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -434,6 +434,38 @@ fn cmd_extract_distributed(args: &cli::ExtractDistributedArgs) -> Result<(), App
 
 // ─── Analyse ──────────────────────────────────────────────────────────────────
 
+/// Format an `AnalysisReport` as a human-readable string.
+/// Exposed for unit testing.
+pub(crate) fn format_analysis_report(report: &crate::domain::types::AnalysisReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "Technique:     {:?}", report.technique);
+    let _ = writeln!(out, "Capacity:      {} bytes", report.cover_capacity.bytes);
+    let _ = writeln!(out, "Chi-square:    {:.2} dB", report.chi_square_score);
+    let _ = writeln!(out, "Risk:          {:?}", report.detectability_risk);
+    let _ = writeln!(
+        out,
+        "Recommended:   {} bytes",
+        report.recommended_max_payload_bytes
+    );
+    if let Some(s) = &report.spectral_score {
+        let _ = writeln!(out, "--- Spectral Detectability ---");
+        let _ = writeln!(out, "  Phase coherence drop: {:.4}", s.phase_coherence_drop);
+        let _ = writeln!(
+            out,
+            "  Carrier SNR drop:     {:.2} dB",
+            s.carrier_snr_drop_db
+        );
+        let _ = writeln!(
+            out,
+            "  Sample-pair asymmetry:{:.4}",
+            s.sample_pair_asymmetry
+        );
+        let _ = writeln!(out, "  Spectral risk:        {:?}", s.combined_risk);
+    }
+    out
+}
+
 fn cmd_analyse(args: &cli::AnalyseArgs) -> Result<(), AppError> {
     let technique = resolve_technique(args.technique);
     let cover = load_cover_from_path(&args.cover, technique)?;
@@ -448,14 +480,7 @@ fn cmd_analyse(args: &cli::AnalyseArgs) -> Result<(), AppError> {
         })?;
         println!("{json}");
     } else {
-        println!("Technique:     {:?}", report.technique);
-        println!("Capacity:      {} bytes", report.cover_capacity.bytes);
-        println!("Chi-square:    {:.2} dB", report.chi_square_score);
-        println!("Risk:          {:?}", report.detectability_risk);
-        println!(
-            "Recommended:   {} bytes",
-            report.recommended_max_payload_bytes
-        );
+        print!("{}", format_analysis_report(&report));
     }
     Ok(())
 }
@@ -1419,5 +1444,80 @@ mod tests {
         let extracted = fs::read(output_path)?;
         assert_eq!(extracted, b"real secret");
         Ok(())
+    }
+
+    // ─── format_analysis_report ───────────────────────────────────────────
+
+    use super::format_analysis_report;
+    use crate::domain::types::{
+        AnalysisReport, Capacity, DetectabilityRisk, SpectralScore, StegoTechnique as ST,
+    };
+
+    fn base_report() -> AnalysisReport {
+        AnalysisReport {
+            technique: ST::LsbImage,
+            cover_capacity: Capacity {
+                bytes: 1024,
+                technique: ST::LsbImage,
+            },
+            chi_square_score: 3.14,
+            detectability_risk: DetectabilityRisk::Low,
+            recommended_max_payload_bytes: 512,
+            spectral_score: None,
+        }
+    }
+
+    #[test]
+    fn format_report_contains_core_fields() {
+        let report = base_report();
+        let out = format_analysis_report(&report);
+        assert!(out.contains("LsbImage"), "technique should appear");
+        assert!(out.contains("1024 bytes"), "capacity should appear");
+        assert!(out.contains("3.14 dB"), "chi-square should appear");
+        assert!(out.contains("Low"), "risk should appear");
+        assert!(out.contains("512 bytes"), "recommended max should appear");
+    }
+
+    #[test]
+    fn format_report_omits_spectral_section_when_none() {
+        let report = base_report();
+        let out = format_analysis_report(&report);
+        assert!(
+            !out.contains("Spectral Detectability"),
+            "spectral section must be absent when score is None"
+        );
+    }
+
+    #[test]
+    fn format_report_includes_spectral_section_when_present() {
+        let mut report = base_report();
+        report.spectral_score = Some(SpectralScore {
+            phase_coherence_drop: 0.1234,
+            carrier_snr_drop_db: -2.5,
+            sample_pair_asymmetry: 0.0081,
+            combined_risk: DetectabilityRisk::Medium,
+        });
+        let out = format_analysis_report(&report);
+        assert!(
+            out.contains("Spectral Detectability"),
+            "section header must appear"
+        );
+        assert!(out.contains("0.1234"), "phase coherence drop should appear");
+        assert!(out.contains("-2.50 dB"), "SNR drop should appear");
+        assert!(
+            out.contains("0.0081"),
+            "sample-pair asymmetry should appear"
+        );
+        assert!(out.contains("Medium"), "spectral risk should appear");
+    }
+
+    #[test]
+    fn format_report_spectral_does_not_bleed_into_core_output() {
+        let report = base_report();
+        let out = format_analysis_report(&report);
+        // Core fields still present even without spectral score
+        assert!(out.contains("Technique"));
+        assert!(out.contains("Chi-square"));
+        assert!(out.contains("Recommended"));
     }
 }

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -9,8 +9,8 @@ const MAX_STDIN_PAYLOAD: u64 = 256 * 1024 * 1024;
 use clap::Parser;
 
 use crate::application::services::{
-    AnalyseService, AppError, ArchiveService, EmbedService, ExtractService, KeyGenService,
-    ScrubService,
+    AnalyseService, AppError, ArchiveService, CipherService, EmbedService, ExtractService,
+    KeyGenService, ScrubService,
 };
 use crate::domain::errors::{CanaryError, OpsecError, StegoError};
 use crate::domain::ports::{EmbedTechnique, ExtractTechnique, GeographicDistributor, MediaLoader};
@@ -51,6 +51,7 @@ pub fn dispatch(cli: Cli) -> Result<(), AppError> {
         Commands::Corpus(args) => cmd_corpus(&args),
         Commands::Panic(args) => cmd_panic(&args),
         Commands::Completions(args) => cmd_completions(&args),
+        Commands::Cipher(args) => cmd_cipher(&args),
     }
 }
 
@@ -748,6 +749,56 @@ fn cmd_completions(args: &cli::CompletionsArgs) -> Result<(), AppError> {
         }
         None => {
             generate(args.shell, &mut cmd, "shadowforge", &mut io::stdout());
+        }
+    }
+    Ok(())
+}
+
+// ─── Cipher ───────────────────────────────────────────────────────────────────
+
+/// AES-256-GCM nonce length in bytes.
+const AES_GCM_NONCE_LEN: usize = 12;
+
+fn cmd_cipher(args: &cli::CipherArgs) -> Result<(), AppError> {
+    use rand_core::Rng as _;
+
+    let cipher = crate::adapters::crypto::Aes256GcmCipher;
+    match &args.subcmd {
+        cli::CipherSubcommand::Encrypt { input, key, output } => {
+            let plaintext = fs_read(input)?;
+            let key_bytes = fs_read(key)?;
+            let mut nonce = [0u8; AES_GCM_NONCE_LEN];
+            rand::rng().fill_bytes(&mut nonce);
+            let ciphertext = CipherService::encrypt(&cipher, &key_bytes, &nonce, &plaintext)?;
+            let mut out = Vec::with_capacity(AES_GCM_NONCE_LEN.strict_add(ciphertext.len()));
+            out.extend_from_slice(&nonce);
+            out.extend_from_slice(&ciphertext);
+            fs_write(output, &out)?;
+            eprintln!(
+                "Encrypted {} bytes -> {}",
+                plaintext.len(),
+                output.display()
+            );
+        }
+        cli::CipherSubcommand::Decrypt { input, key, output } => {
+            let data = fs_read(input)?;
+            let key_bytes = fs_read(key)?;
+            if data.len() < AES_GCM_NONCE_LEN {
+                return Err(AppError::Crypto(
+                    crate::domain::errors::CryptoError::InvalidNonceLength {
+                        expected: AES_GCM_NONCE_LEN,
+                        got: data.len(),
+                    },
+                ));
+            }
+            let (nonce, ciphertext) = data.split_at(AES_GCM_NONCE_LEN);
+            let plaintext = CipherService::decrypt(&cipher, &key_bytes, nonce, ciphertext)?;
+            fs_write(output, &plaintext)?;
+            eprintln!(
+                "Decrypted {} bytes -> {}",
+                plaintext.len(),
+                output.display()
+            );
         }
     }
     Ok(())

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -775,7 +775,9 @@ fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
             let payload = Payload::from_bytes(data);
             let tech = resolve_technique(*technique);
 
-            // If --model is provided, use model-aware search.
+            // If --model is provided, use model-aware search.  --resolution
+            // is required in that case; an absent or unparseable value returns
+            // a clear error rather than silently falling back to (0, 0).
             let results = if let Some(model_id) = model {
                 let res = resolution
                     .as_deref()
@@ -785,7 +787,13 @@ fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
                         let h = parts.next()?.parse::<u32>().ok()?;
                         Some((w, h))
                     })
-                    .unwrap_or((0, 0));
+                    .ok_or_else(|| {
+                        AppError::Stego(StegoError::MalformedCoverData {
+                            reason: "--model requires --resolution in WIDTHxHEIGHT format \
+                                     (e.g. --resolution 1024x1024)"
+                                .to_string(),
+                        })
+                    })?;
                 CorpusService::search_for_model(&index, &payload, model_id, res, *top)?
             } else {
                 CorpusService::search(&index, &payload, tech, *top)?

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -354,9 +354,8 @@ fn distribute_covers(
         args.data_shards,
         args.parity_shards,
     );
-    let matcher = crate::adapters::adaptive::CoverProfileMatcherImpl::with_built_in();
-    let optimiser = crate::adapters::adaptive::AdaptiveOptimiserImpl::with_built_in();
-    let compressor = crate::adapters::adaptive::CompressionSimulatorImpl;
+    let (matcher, optimiser, compressor) =
+        crate::adapters::adaptive::build_adaptive_profile_deps();
 
     let stego_covers =
         crate::application::services::DistributeService::distribute_with_profile_hardening(
@@ -1228,9 +1227,7 @@ fn resolve_profile(
 ) -> crate::domain::types::EmbeddingProfile {
     match profile {
         cli::Profile::Standard => crate::domain::types::EmbeddingProfile::Standard,
-        cli::Profile::Adaptive => crate::domain::types::EmbeddingProfile::Adaptive {
-            max_detectability_db: -12.0,
-        },
+        cli::Profile::Adaptive => crate::domain::types::EmbeddingProfile::default_adaptive(),
         cli::Profile::Survivable => {
             let p = platform.map_or(crate::domain::types::PlatformProfile::Instagram, |pl| {
                 resolve_platform(pl)

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -353,13 +353,23 @@ fn distribute_covers(
         args.data_shards,
         args.parity_shards,
     );
-    let stego_covers = crate::application::services::DistributeService::distribute(
-        payload,
-        covers,
-        profile,
-        &distributor,
-        embedder,
-    )?;
+    let matcher = crate::adapters::adaptive::CoverProfileMatcherImpl::with_built_in();
+    let optimiser = crate::adapters::adaptive::AdaptiveOptimiserImpl::with_built_in();
+    let compressor = crate::adapters::adaptive::CompressionSimulatorImpl;
+
+    let stego_covers =
+        crate::application::services::DistributeService::distribute_with_profile_hardening(
+            payload,
+            covers,
+            profile,
+            &distributor,
+            embedder,
+            &crate::application::services::AdaptiveProfileDeps {
+                matcher: &matcher,
+                optimiser: &optimiser,
+                compressor: &compressor,
+            },
+        )?;
     Ok((stego_covers, generated_hmac_key))
 }
 

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -676,11 +676,29 @@ fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
             input,
             technique,
             top,
+            model,
+            resolution,
         } => {
             let data = fs_read(input)?;
             let payload = Payload::from_bytes(data);
             let tech = resolve_technique(*technique);
-            let results = index.search(&payload, tech, *top)?;
+
+            // If --model is provided, use model-aware search.
+            let results = if let Some(model_id) = model {
+                let res = resolution
+                    .as_deref()
+                    .and_then(|s| {
+                        let mut parts = s.splitn(2, 'x');
+                        let w = parts.next()?.parse::<u32>().ok()?;
+                        let h = parts.next()?.parse::<u32>().ok()?;
+                        Some((w, h))
+                    })
+                    .unwrap_or((0, 0));
+                index.search_for_model(&payload, model_id, res, *top)?
+            } else {
+                index.search(&payload, tech, *top)?
+            };
+
             for entry in &results {
                 println!("{}", entry.path);
             }


### PR DESCRIPTION
## Summary

This branch (`feat/wiring-boundary-hardening`) wires up and hardens a broader set of subsystems than the original description indicated. Full scope:

### Features added / completed
- **Keygen CLI** — `keygen sign` / `keygen verify` subcommands (ML-DSA-87) now fully wired through the CLI dispatcher (`interface/runner.rs`)
- **Cipher CLI** — `embed cipher` / `extract cipher` subcommands wired (AES-256-GCM symmetric path)
- **Spectral analysis primitives** — `spectral_detectability_score`, `pair_delta_chi_square_score`, `top_magnitude_bins`, `compute_phase_coherence_drop`, `compute_carrier_snr_drop_db` in `domain/analysis`
- **Adaptive embedding primitives** — `BinMask`, `permutation_search`, `Permutation`, `SearchConfig`, `cost_at` in `domain/adaptive`; `rustfft` dependency added
- **Corpus model-aware indexing/search** — `CorpusIndexImpl::add_to_index` and `CorpusService::search_for_model` wired to the CLI; `CorpusEntry` carries optional `spectral_key` field for future enrichment
- **Geographic distribution boundary hardening** — manifest validation enforces shard count ≤ threshold_k and jurisdiction count ≥ required_jurisdictions at service entry-point

### Bug fixes / hardening (addressing Copilot review)
- **Thread 1** — `with_built_in()` now emits `tracing::error!` instead of silently discarding codebook parse failures
- **Thread 4** — `permutation_search` uses `pair_delta_chi_square_score` (order-sensitive consecutive-byte-delta histogram) so the hill-climb actually converges
- **Thread 5** — `spectral_detectability_score` extracts real image dimensions from cover metadata and uses flat `row * width + col` bin indexing
- **Thread 6** — `CarrierBin::coherence` is clamped on JSON deserialization via `#[serde(deserialize_with = "de_clamp_coherence")]`
- **Thread 7** — Profile-matching FFT step is skipped entirely for `Standard` and `CorpusBased` embedding profiles (no-op path is now O(1))
- **Thread 8** — `profile_for` uses `row * width + col` (not just `col`) for 1-D FFT bin index
- **Thread 10** — `CameraProfile::quantisation_table` changed from `Vec<u16>` to `[u16; 64]` for compile-time length invariant; `serde_quant_table` helper provides wire-format compatibility
- **Thread 11** — Cover-count mismatch after distribution now raises `AdaptiveError::DistributionCountMismatch { got, expected }` instead of the misleading `ProfileMatchFailed`
- **Thread 12** — `--resolution` is required (not silently `(0, 0)`) when `--model` is specified in corpus search; returns a clear `AppError::Stego(MalformedCoverData)` on failure

### Test / lint
- Workspace lint config centralised in root `Cargo.toml` (`[workspace.lints]`)
- 453 tests passing, 0 failures, `cargo clippy --workspace -- -D warnings` clean