### PR TITLE
feat: pdfium auto-detection and feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,7 @@ render-to-PNG pipeline is unavailable.
 The build process will auto-detect pdfium if:
 
 - Set via `PDFIUM_DYNAMIC_LIB_PATH` environment variable
-- Installed in common system paths (`/opt/homebrew/lib`, `/usr/lib`, etc.)
-- Already downloaded and available on the system PATH
+- Found in a standard system library directory (`/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu` on Linux/macOS; `C:\Program Files\pdfium\lib` on Windows)
 
 If pdfium is not found, the build will emit a warning with setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ cargo build --no-default-features
 # Disable only PDF
 cargo build --no-default-features --features corpus,adaptive
 
-# Enable only SIMD (for performance-critical deployments)
+# Enable SIMD in addition to defaults (for performance-critical deployments)
 cargo build --features simd
+
+# Enable only SIMD without defaults
+cargo build --no-default-features --features simd
 ```
 
 ### Installing from crates.io
@@ -172,6 +175,7 @@ The build process will auto-detect pdfium if:
 
 - Set via `PDFIUM_DYNAMIC_LIB_PATH` environment variable
 - Found in a standard system library directory (`/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu` on Linux/macOS; `C:\Program Files\pdfium\lib` on Windows)
+- Found via the OS dynamic loader's configured library search paths
 
 If pdfium is not found, the build will emit a warning with setup instructions.
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ shadowforge = { version = "0.3", default-features = false }
 
 ```bash
 # Install with all features (default)
-cargo install shadowforge-rs
+cargo install shadowforge
 
 # Install without PDF support
-cargo install shadowforge-rs --no-default-features --features corpus,adaptive
+cargo install shadowforge --no-default-features --features corpus,adaptive
 
 # Install from source with specific features
 git clone https://github.com/greysquirr3l/shadowforge-rs

--- a/README.md
+++ b/README.md
@@ -101,6 +101,97 @@ export PDFIUM_DYNAMIC_LIB_PATH="$(pwd)/lib"
 To persist the environment variable, add the `export` line to your shell
 profile (`~/.bashrc`, `~/.zshrc`, etc.).
 
+---
+
+## Building with Features
+
+shadowforge-rs uses Cargo's optional feature system to control which capabilities are compiled in. This allows users to reduce the attack surface and dependencies by disabling features they don't need.
+
+### Available Features
+
+| Feature | Default | Purpose |
+|---------|---------|---------|
+| `pdf` | ✅ | PDF embedding/extraction and page rasterisation (requires pdfium) |
+| `corpus` | ✅ | Corpus-based steganography (zero-modification cover selection) |
+| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) |
+| `simd` | ❌ | SIMD acceleration for Reed-Solomon (if available on platform) |
+
+### Disabling Features
+
+By default, `pdf`, `corpus`, and `adaptive` are enabled. To build with fewer features:
+
+```bash
+# Disable all optional features
+cargo build --no-default-features
+
+# Disable only PDF
+cargo build --no-default-features --features corpus,adaptive
+
+# Enable only SIMD (for performance-critical deployments)
+cargo build --features simd
+```
+
+### Installing from crates.io
+
+When using shadowforge-rs as a dependency:
+
+```toml
+# In your Cargo.toml
+[dependencies]
+shadowforge = "0.3"  # All default features enabled
+
+# Or with specific features
+shadowforge = { version = "0.3", features = ["corpus"] }
+
+# Or with no features
+shadowforge = { version = "0.3", default-features = false }
+```
+
+### Installing the Binary with Features
+
+```bash
+# Install with all features (default)
+cargo install shadowforge-rs
+
+# Install without PDF support
+cargo install shadowforge-rs --no-default-features --features corpus,adaptive
+
+# Install from source with specific features
+git clone https://github.com/greysquirr3l/shadowforge-rs
+cd shadowforge-rs
+cargo install --path crates/shadowforge --features pdf,corpus,adaptive
+```
+
+### PDF Support (Optional)
+
+PDF page rasterisation requires the pdfium shared library. Without it,
+PDF content-stream and metadata steganography still work, but the
+render-to-PNG pipeline is unavailable.
+
+The build process will auto-detect pdfium if:
+
+- Set via `PDFIUM_DYNAMIC_LIB_PATH` environment variable
+- Installed in common system paths (`/opt/homebrew/lib`, `/usr/lib`, etc.)
+- Already downloaded and available on the system PATH
+
+If pdfium is not found, the build will emit a warning with setup instructions.
+
+To manually set up pdfium:
+
+```bash
+# macOS (Apple Silicon)
+curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-arm64.tgz | tar xz
+export PDFIUM_DYNAMIC_LIB_PATH="$(pwd)/lib"
+
+# macOS (Intel)
+curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-x64.tgz | tar xz
+export PDFIUM_DYNAMIC_LIB_PATH="$(pwd)/lib"
+
+# Linux (x86_64)
+curl -L https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-linux-x64.tgz | tar xz
+export PDFIUM_DYNAMIC_LIB_PATH="$(pwd)/lib"
+```
+
 ### Shell Completions
 
 ```bash

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -22,11 +22,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn check_pdfium_availability() {
     // Re-run this check whenever the user changes the override variable or build target.
     println!("cargo:rerun-if-env-changed=PDFIUM_DYNAMIC_LIB_PATH");
-    println!("cargo:rerun-if-changed=unknown");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
 
     let env_var = "PDFIUM_DYNAMIC_LIB_PATH";
-    if let Ok(custom_path) = env::var(env_var) {
+    if let Some(custom_path_os) = env::var_os(env_var) {
         // User explicitly configured the path — validate it contains the pdfium library.
+        // Use var_os to accept any valid filesystem path, not just valid UTF-8.
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
         let lib_name: &str = if target_os == "macos" {
             "libpdfium.dylib"
@@ -35,15 +36,16 @@ fn check_pdfium_availability() {
         } else {
             "libpdfium.so"
         };
-        let custom_path_obj = Path::new(&custom_path);
+        let custom_path_obj = Path::new(&custom_path_os);
         let lib_found = if custom_path_obj.is_dir() {
             custom_path_obj.join(lib_name).exists()
         } else {
             custom_path_obj.exists()
         };
         if !lib_found {
+            let display = custom_path_os.to_string_lossy();
             println!(
-                "cargo:warning=PDFIUM_DYNAMIC_LIB_PATH='{custom_path}' does not contain {lib_name}. PDF rasterisation will fail at runtime."
+                "cargo:warning=PDFIUM_DYNAMIC_LIB_PATH='{display}' does not contain {lib_name}. PDF rasterisation will fail at runtime."
             );
         }
         return;
@@ -64,6 +66,13 @@ fn check_pdfium_availability() {
         &[
             "C:\\Program Files\\pdfium\\lib",
             "C:\\Program Files (x86)\\pdfium\\lib",
+        ]
+    } else if target_os == "macos" {
+        &[
+            "/opt/homebrew/lib",
+            "/opt/local/lib",
+            "/usr/local/lib",
+            "/usr/lib",
         ]
     } else {
         &[
@@ -100,5 +109,5 @@ fn check_pdfium_availability() {
         "cargo:warning=  Windows: Download from https://github.com/bblanchon/pdfium-binaries/"
     );
     println!("cargo:warning=");
-    println!("cargo:warning=Or disable PDF: cargo build --no-default-features");
+    println!("cargo:warning=Or disable only PDF: cargo build --no-default-features --features corpus,adaptive");
 }

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -20,10 +20,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Check if pdfium is available; emit helpful message if not.
 fn check_pdfium_availability() {
     let pdfium_paths = vec![
-        // macOS homebrew (custom install)
-        "/opt/homebrew/lib",
+        // Common Unix paths (user-compiled or manually installed)
         "/usr/local/lib",
-        // Linux
         "/usr/lib",
         "/usr/lib/x86_64-linux-gnu",
         "/usr/lib/aarch64-linux-gnu",

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -1,4 +1,6 @@
-//! Build script: embeds git SHA and commit timestamp via vergen.
+//! Build script: embeds git SHA, commit timestamp, and checks pdfium availability.
+use std::env;
+use std::path::Path;
 use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,5 +8,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .git_sha(false)
         .git_commit_timestamp()
         .emit()?;
+
+    // Check if PDF feature is enabled
+    if cfg!(feature = "pdf") {
+        check_pdfium_availability();
+    }
+
     Ok(())
+}
+
+/// Check if pdfium is available; emit helpful message if not.
+fn check_pdfium_availability() {
+    let pdfium_paths = vec![
+        // macOS homebrew (custom install)
+        "/opt/homebrew/lib",
+        "/usr/local/lib",
+        // Linux
+        "/usr/lib",
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        // Windows
+        "C:\\Program Files\\pdfium\\lib",
+        "C:\\Program Files (x86)\\pdfium\\lib",
+    ];
+
+    let env_var = "PDFIUM_DYNAMIC_LIB_PATH";
+    if let Ok(custom_path) = env::var(env_var)
+        && Path::new(&custom_path).exists()
+    {
+        println!("cargo:warning=pdfium detected at {custom_path}");
+        return;
+    }
+
+    // Check standard paths
+    for path in &pdfium_paths {
+        if Path::new(path).exists() {
+            println!("cargo:warning=pdfium auto-detected at {path}");
+            println!("cargo:warning=Set PDFIUM_DYNAMIC_LIB_PATH={path} to use it explicitly");
+            return;
+        }
+    }
+
+    // Not found — emit instructions
+    println!("cargo:warning=pdfium library not found. PDF features will fail at runtime.");
+    println!("cargo:warning=");
+    println!("cargo:warning=To set up pdfium:");
+    println!("cargo:warning=  macOS:   Download from https://pdfium.googlesource.com/");
+    println!(
+        "cargo:warning=           Extract and set: export PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib"
+    );
+    println!("cargo:warning=  Linux:   apt install libpdfium (if available) or build from source");
+    println!("cargo:warning=  Windows: Download prebuilt or build from source");
+    println!("cargo:warning=");
+    println!("cargo:warning=Or disable PDF: cargo build --no-default-features");
 }

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -9,54 +9,81 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .git_commit_timestamp()
         .emit()?;
 
-    // Check if PDF feature is enabled
-    if cfg!(feature = "pdf") {
+    // CARGO_FEATURE_PDF is set by Cargo when the `pdf` feature is enabled.
+    // cfg!(feature = ...) does not reflect enabled features in build scripts.
+    if env::var("CARGO_FEATURE_PDF").is_ok() {
         check_pdfium_availability();
     }
 
     Ok(())
 }
 
-/// Check if pdfium is available; emit helpful message if not.
+/// Check if the pdfium shared library is findable; emit a warning only when it is not.
 fn check_pdfium_availability() {
-    let pdfium_paths = vec![
-        // Common Unix paths (user-compiled or manually installed)
-        "/usr/local/lib",
-        "/usr/lib",
-        "/usr/lib/x86_64-linux-gnu",
-        "/usr/lib/aarch64-linux-gnu",
-        // Windows
-        "C:\\Program Files\\pdfium\\lib",
-        "C:\\Program Files (x86)\\pdfium\\lib",
-    ];
+    // Re-run this check whenever the user changes the override variable.
+    println!("cargo:rerun-if-env-changed=PDFIUM_DYNAMIC_LIB_PATH");
 
     let env_var = "PDFIUM_DYNAMIC_LIB_PATH";
-    if let Ok(custom_path) = env::var(env_var)
-        && Path::new(&custom_path).exists()
-    {
-        println!("cargo:warning=pdfium detected at {custom_path}");
+    if let Ok(custom_path) = env::var(env_var) {
+        // User explicitly configured the path — only warn if it does not exist.
+        if !Path::new(&custom_path).exists() {
+            println!(
+                "cargo:warning=PDFIUM_DYNAMIC_LIB_PATH is set to '{custom_path}' but the path does not exist."
+            );
+        }
         return;
     }
 
-    // Check standard paths
-    for path in &pdfium_paths {
-        if Path::new(path).exists() {
-            println!("cargo:warning=pdfium auto-detected at {path}");
-            println!("cargo:warning=Set PDFIUM_DYNAMIC_LIB_PATH={path} to use it explicitly");
+    // Platform-specific library filename for the build target.
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let lib_name: &str = if target_os == "macos" {
+        "libpdfium.dylib"
+    } else if target_os == "windows" {
+        "pdfium.dll"
+    } else {
+        "libpdfium.so"
+    };
+
+    // Standard installation directories per platform.
+    let search_dirs: &[&str] = if target_os == "windows" {
+        &[
+            "C:\\Program Files\\pdfium\\lib",
+            "C:\\Program Files (x86)\\pdfium\\lib",
+        ]
+    } else {
+        &[
+            "/usr/local/lib",
+            "/usr/lib",
+            "/usr/lib/x86_64-linux-gnu",
+            "/usr/lib/aarch64-linux-gnu",
+        ]
+    };
+
+    for dir in search_dirs {
+        if Path::new(dir).join(lib_name).exists() {
+            // Found in a standard location — no noise.
             return;
         }
     }
 
-    // Not found — emit instructions
-    println!("cargo:warning=pdfium library not found. PDF features will fail at runtime.");
+    // Not found in any standard location — emit setup instructions.
+    println!(
+        "cargo:warning=pdfium library ({lib_name}) not found. PDF features will fail at runtime."
+    );
     println!("cargo:warning=");
     println!("cargo:warning=To set up pdfium:");
-    println!("cargo:warning=  macOS:   Download from https://pdfium.googlesource.com/");
+    println!(
+        "cargo:warning=  macOS:   Download from https://github.com/bblanchon/pdfium-binaries/"
+    );
     println!(
         "cargo:warning=           Extract and set: export PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib"
     );
-    println!("cargo:warning=  Linux:   apt install libpdfium (if available) or build from source");
-    println!("cargo:warning=  Windows: Download prebuilt or build from source");
+    println!(
+        "cargo:warning=  Linux:   Download from https://github.com/bblanchon/pdfium-binaries/ or build from source"
+    );
+    println!(
+        "cargo:warning=  Windows: Download from https://github.com/bblanchon/pdfium-binaries/"
+    );
     println!("cargo:warning=");
     println!("cargo:warning=Or disable PDF: cargo build --no-default-features");
 }

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -109,5 +109,7 @@ fn check_pdfium_availability() {
         "cargo:warning=  Windows: Download from https://github.com/bblanchon/pdfium-binaries/"
     );
     println!("cargo:warning=");
-    println!("cargo:warning=Or disable only PDF: cargo build --no-default-features --features corpus,adaptive");
+    println!(
+        "cargo:warning=Or disable only PDF: cargo build --no-default-features --features corpus,adaptive"
+    );
 }

--- a/crates/shadowforge/build.rs
+++ b/crates/shadowforge/build.rs
@@ -20,15 +20,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Check if the pdfium shared library is findable; emit a warning only when it is not.
 fn check_pdfium_availability() {
-    // Re-run this check whenever the user changes the override variable.
+    // Re-run this check whenever the user changes the override variable or build target.
     println!("cargo:rerun-if-env-changed=PDFIUM_DYNAMIC_LIB_PATH");
+    println!("cargo:rerun-if-changed=unknown");
 
     let env_var = "PDFIUM_DYNAMIC_LIB_PATH";
     if let Ok(custom_path) = env::var(env_var) {
-        // User explicitly configured the path — only warn if it does not exist.
-        if !Path::new(&custom_path).exists() {
+        // User explicitly configured the path — validate it contains the pdfium library.
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let lib_name: &str = if target_os == "macos" {
+            "libpdfium.dylib"
+        } else if target_os == "windows" {
+            "pdfium.dll"
+        } else {
+            "libpdfium.so"
+        };
+        let custom_path_obj = Path::new(&custom_path);
+        let lib_found = if custom_path_obj.is_dir() {
+            custom_path_obj.join(lib_name).exists()
+        } else {
+            custom_path_obj.exists()
+        };
+        if !lib_found {
             println!(
-                "cargo:warning=PDFIUM_DYNAMIC_LIB_PATH is set to '{custom_path}' but the path does not exist."
+                "cargo:warning=PDFIUM_DYNAMIC_LIB_PATH='{custom_path}' does not contain {lib_name}. PDF rasterisation will fail at runtime."
             );
         }
         return;
@@ -68,7 +83,7 @@ fn check_pdfium_availability() {
 
     // Not found in any standard location — emit setup instructions.
     println!(
-        "cargo:warning=pdfium library ({lib_name}) not found. PDF features will fail at runtime."
+        "cargo:warning=pdfium library ({lib_name}) not found. PDF rasterisation will be unavailable unless pdfium is discoverable via system library paths."
     );
     println!("cargo:warning=");
     println!("cargo:warning=To set up pdfium:");

--- a/crates/shadowforge/src/adapters/pdf.rs
+++ b/crates/shadowforge/src/adapters/pdf.rs
@@ -58,11 +58,11 @@ impl PdfProcessorImpl {
             }
         }
 
-        // 2. Try auto-downloaded pdfium (built by cargo with pdfium_download feature)
+        // 2. Try system library (searched via the OS dynamic linker)
         match Pdfium::bind_to_system_library() {
             Ok(bindings) => return Ok(Pdfium::new(bindings)),
             Err(error) => {
-                bind_errors.push(format!("auto-downloaded pdfium: {error}"));
+                bind_errors.push(format!("system library: {error}"));
             }
         }
 
@@ -77,10 +77,11 @@ impl PdfProcessorImpl {
         Err(PdfError::RenderFailed {
             page: 0,
             reason: format!(
-                "Failed to load pdfium library. Auto-download during build should have handled this.\n\
-                 If you have a custom pdfium build, set PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib.\n\
-                 Paths tried: {}",
-                bind_errors.join(", ")
+                "Failed to load pdfium library. Attempted: {}.\n\
+                 Download a prebuilt binary from https://github.com/bblanchon/pdfium-binaries/ \n\
+                 and set PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib, \n\
+                 or disable the pdf feature with --no-default-features.",
+                bind_errors.join("; ")
             ),
         })
     }

--- a/crates/shadowforge/src/adapters/pdf.rs
+++ b/crates/shadowforge/src/adapters/pdf.rs
@@ -632,9 +632,11 @@ fn map_pdf_error(error: PdfError) -> StegoError {
         PdfError::ParseFailed { reason }
         | PdfError::RebuildFailed { reason }
         | PdfError::EmbedFailed { reason }
-        | PdfError::IoError { reason }
-        | PdfError::BindFailed { reason } => StegoError::MalformedCoverData {
+        | PdfError::IoError { reason } => StegoError::MalformedCoverData {
             reason: format!("pdf processing failed: {reason}"),
+        },
+        PdfError::BindFailed { reason } => StegoError::UnsupportedCoverType {
+            reason: format!("pdfium library is not available: {reason}"),
         },
     }
 }

--- a/crates/shadowforge/src/adapters/pdf.rs
+++ b/crates/shadowforge/src/adapters/pdf.rs
@@ -46,6 +46,7 @@ impl PdfProcessorImpl {
     fn bind_pdfium() -> Result<Pdfium, PdfError> {
         let mut bind_errors = Vec::new();
 
+        // 1. Try explicit env var override (highest priority)
         if let Some(pdfium_dir) = env::var_os("PDFIUM_DYNAMIC_LIB_PATH") {
             let library_path = Pdfium::pdfium_platform_library_name_at_path(&pdfium_dir);
             match Pdfium::bind_to_library(library_path) {
@@ -57,25 +58,31 @@ impl PdfProcessorImpl {
             }
         }
 
+        // 2. Try auto-downloaded pdfium (built by cargo with pdfium_download feature)
+        match Pdfium::bind_to_system_library() {
+            Ok(bindings) => return Ok(Pdfium::new(bindings)),
+            Err(error) => {
+                bind_errors.push(format!("auto-downloaded pdfium: {error}"));
+            }
+        }
+
+        // 3. Try local directory (e.g., ./)
         let local_library = Pdfium::pdfium_platform_library_name_at_path("./");
         match Pdfium::bind_to_library(local_library) {
             Ok(bindings) => return Ok(Pdfium::new(bindings)),
             Err(error) => bind_errors.push(format!("./: {error}")),
         }
 
-        match Pdfium::bind_to_system_library() {
-            Ok(bindings) => Ok(Pdfium::new(bindings)),
-            Err(error) => {
-                bind_errors.push(format!("system library: {error}"));
-                Err(PdfError::RenderFailed {
-                    page: 0,
-                    reason: format!(
-                        "Failed to load pdfium library. Tried {}",
-                        bind_errors.join(", ")
-                    ),
-                })
-            }
-        }
+        // 4. Fail with helpful error
+        Err(PdfError::RenderFailed {
+            page: 0,
+            reason: format!(
+                "Failed to load pdfium library. Auto-download during build should have handled this.\n\
+                 If you have a custom pdfium build, set PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib.\n\
+                 Paths tried: {}",
+                bind_errors.join(", ")
+            ),
+        })
     }
 }
 

--- a/crates/shadowforge/src/adapters/pdf.rs
+++ b/crates/shadowforge/src/adapters/pdf.rs
@@ -73,14 +73,12 @@ impl PdfProcessorImpl {
             Err(error) => bind_errors.push(format!("./: {error}")),
         }
 
-        // 4. Fail with helpful error
-        Err(PdfError::RenderFailed {
-            page: 0,
+        // 4. Fail with helpful error — use PdfError::BindFailed so it's not confused with a page render failure
+        Err(PdfError::BindFailed {
             reason: format!(
-                "Failed to load pdfium library. Attempted: {}.\n\
-                 Download a prebuilt binary from https://github.com/bblanchon/pdfium-binaries/ \n\
-                 and set PDFIUM_DYNAMIC_LIB_PATH=/path/to/lib, \n\
-                 or disable the pdf feature with --no-default-features.",
+                "Failed to load pdfium library. Binding attempts: {}. \
+                 Download a prebuilt binary from https://github.com/bblanchon/pdfium-binaries/, \
+                 set PDFIUM_DYNAMIC_LIB_PATH, or disable the 'pdf' feature with --no-default-features --features corpus,adaptive.",
                 bind_errors.join("; ")
             ),
         })
@@ -634,7 +632,8 @@ fn map_pdf_error(error: PdfError) -> StegoError {
         PdfError::ParseFailed { reason }
         | PdfError::RebuildFailed { reason }
         | PdfError::EmbedFailed { reason }
-        | PdfError::IoError { reason } => StegoError::MalformedCoverData {
+        | PdfError::IoError { reason }
+        | PdfError::BindFailed { reason } => StegoError::MalformedCoverData {
             reason: format!("pdf processing failed: {reason}"),
         },
     }

--- a/crates/shadowforge/src/domain/errors.rs
+++ b/crates/shadowforge/src/domain/errors.rs
@@ -222,6 +222,12 @@ pub enum PdfError {
     /// The PDF document is encrypted and cannot be processed.
     #[error("PDF is encrypted and cannot be processed")]
     Encrypted,
+    /// Failed to bind or load the pdfium shared library at runtime.
+    #[error("pdfium library binding failed: {reason}")]
+    BindFailed {
+        /// Details about which binding attempts were tried and why they failed.
+        reason: String,
+    },
 }
 
 // ─── DistributionError ────────────────────────────────────────────────────────

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -979,7 +979,8 @@ fn map_pdf_runner_error(error: crate::domain::errors::PdfError) -> AppError {
         | crate::domain::errors::PdfError::RebuildFailed { reason }
         | crate::domain::errors::PdfError::EmbedFailed { reason }
         | crate::domain::errors::PdfError::ExtractFailed { reason }
-        | crate::domain::errors::PdfError::IoError { reason } => {
+        | crate::domain::errors::PdfError::IoError { reason }
+        | crate::domain::errors::PdfError::BindFailed { reason } => {
             AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData { reason })
         }
     }

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -979,10 +979,14 @@ fn map_pdf_runner_error(error: crate::domain::errors::PdfError) -> AppError {
         | crate::domain::errors::PdfError::RebuildFailed { reason }
         | crate::domain::errors::PdfError::EmbedFailed { reason }
         | crate::domain::errors::PdfError::ExtractFailed { reason }
-        | crate::domain::errors::PdfError::IoError { reason }
-        | crate::domain::errors::PdfError::BindFailed { reason } => {
+        | crate::domain::errors::PdfError::IoError { reason } => {
             AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData { reason })
         }
+        crate::domain::errors::PdfError::BindFailed { reason } => AppError::Stego(
+            crate::domain::errors::StegoError::UnsupportedCoverType {
+                reason: format!("pdfium library is not available: {reason}"),
+            },
+        ),
     }
 }
 

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -982,11 +982,11 @@ fn map_pdf_runner_error(error: crate::domain::errors::PdfError) -> AppError {
         | crate::domain::errors::PdfError::IoError { reason } => {
             AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData { reason })
         }
-        crate::domain::errors::PdfError::BindFailed { reason } => AppError::Stego(
-            crate::domain::errors::StegoError::UnsupportedCoverType {
+        crate::domain::errors::PdfError::BindFailed { reason } => {
+            AppError::Stego(crate::domain::errors::StegoError::UnsupportedCoverType {
                 reason: format!("pdfium library is not available: {reason}"),
-            },
-        ),
+            })
+        }
     }
 }
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -28,7 +28,9 @@ shadowforge-rs uses optional features to control which capabilities are compiled
 |---------|---------|---------|
 | `pdf` | ✅ | PDF embedding/extraction and page rasterisation (requires pdfium) |
 | `corpus` | ✅ | Corpus-based steganography (zero-modification cover selection) |
-| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) || `simd` | ❌ | SIMD-accelerated operations (for performance-critical deployments) |
+| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) |
+| `simd` | ❌ | SIMD-accelerated operations (for performance-critical deployments) |
+
 ### Building with Specific Features
 
 ```bash

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -58,7 +58,7 @@ The build process will auto-detect pdfium if:
 - Set via the `PDFIUM_DYNAMIC_LIB_PATH` environment variable
 - Found in a standard system library path (`/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu` on Linux/macOS; `C:\Program Files\pdfium\lib` on Windows)
 
-If pdfium is not found, the build will emit a warning. If you're building without the `pdf` feature, this warning can be safely ignored.
+If pdfium is not found, the build will emit a warning. (Note: this warning only appears when the `pdf` feature is enabled; builds without it proceed silently.)
 
 ### macOS (Apple Silicon)
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -12,10 +12,35 @@
 git clone https://github.com/greysquirr3l/shadowforge-rs.git
 cd shadowforge-rs
 
-# Build in release mode
+# Build in release mode (all default features enabled)
 cargo build --release
 
 # The binary is at target/release/shadowforge
+```
+
+## Cargo Features
+
+shadowforge-rs uses optional features to control which capabilities are compiled in. This allows you to reduce the attack surface and build dependencies by disabling features you don't need.
+
+### Available Features
+
+| Feature | Default | Purpose |
+|---------|---------|---------|
+| `pdf` | ✅ | PDF embedding/extraction and page rasterisation (requires pdfium) |
+| `corpus` | ✅ | Corpus-based steganography (zero-modification cover selection) |
+| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) |
+
+### Building with Specific Features
+
+```bash
+# Disable all optional features
+cargo build --release --no-default-features
+
+# Disable only PDF support
+cargo build --release --no-default-features --features corpus,adaptive
+
+# Disable only adaptive embedding
+cargo build --release --no-default-features --features pdf,corpus
 ```
 
 ## Verify Installation
@@ -27,6 +52,14 @@ shadowforge version
 ## PDF Support (Optional)
 
 PDF page rasterisation requires the pdfium shared library. Without it, PDF content-stream and metadata steganography still work, but the render-to-PNG pipeline is unavailable.
+
+The build process will auto-detect pdfium if:
+
+- Set via the `PDFIUM_DYNAMIC_LIB_PATH` environment variable
+- Installed in common system paths (`/opt/homebrew/lib`, `/usr/local/lib`, `/usr/lib`, etc.)
+- Already available on the system PATH
+
+If pdfium is not found, the build will emit a warning. If you're building without the `pdf` feature, this warning can be safely ignored.
 
 ### macOS (Apple Silicon)
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -28,8 +28,7 @@ shadowforge-rs uses optional features to control which capabilities are compiled
 |---------|---------|---------|
 | `pdf` | ✅ | PDF embedding/extraction and page rasterisation (requires pdfium) |
 | `corpus` | ✅ | Corpus-based steganography (zero-modification cover selection) |
-| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) |
-
+| `adaptive` | ✅ | Adaptive embedding (STC-inspired steganalysis evasion) || `simd` | ❌ | SIMD-accelerated operations (for performance-critical deployments) |
 ### Building with Specific Features
 
 ```bash
@@ -56,7 +55,10 @@ PDF page rasterisation requires the pdfium shared library. Without it, PDF conte
 The build process will auto-detect pdfium if:
 
 - Set via the `PDFIUM_DYNAMIC_LIB_PATH` environment variable
-- Found in a standard system library path (`/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu` on Linux/macOS; `C:\Program Files\pdfium\lib` on Windows)
+- Found in a standard system library path:
+  - macOS: `/opt/homebrew/lib` (Homebrew), `/opt/local/lib` (MacPorts), `/usr/local/lib`, `/usr/lib`
+  - Linux: `/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu`
+  - Windows: `C:\Program Files\pdfium\lib`, `C:\Program Files (x86)\pdfium\lib`
 
 If pdfium is not found, the build will emit a warning. (Note: this warning only appears when the `pdf` feature is enabled; builds without it proceed silently.)
 

--- a/docs/src/guide/installation.md
+++ b/docs/src/guide/installation.md
@@ -56,8 +56,7 @@ PDF page rasterisation requires the pdfium shared library. Without it, PDF conte
 The build process will auto-detect pdfium if:
 
 - Set via the `PDFIUM_DYNAMIC_LIB_PATH` environment variable
-- Installed in common system paths (`/opt/homebrew/lib`, `/usr/local/lib`, `/usr/lib`, etc.)
-- Already available on the system PATH
+- Found in a standard system library path (`/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu` on Linux/macOS; `C:\Program Files\pdfium\lib` on Windows)
 
 If pdfium is not found, the build will emit a warning. If you're building without the `pdf` feature, this warning can be safely ignored.
 


### PR DESCRIPTION
## Overview

Improve pdfium setup experience with automatic detection and comprehensive feature documentation.

## Changes

### Auto-Detection (build.rs)
- Automatically detect pdfium in standard system paths:
  - Unix: `/usr/local/lib`, `/usr/lib`, `/usr/lib/x86_64-linux-gnu`, `/usr/lib/aarch64-linux-gnu`
  - Windows: `C:\Program Files\pdfium\lib`
- Emit clear warnings with setup instructions if not found
- Respect explicit `PDFIUM_DYNAMIC_LIB_PATH` env var override
- Graceful degradation for builds without PDF feature

### Binding Priority (adapters/pdf.rs)
1. Explicit `PDFIUM_DYNAMIC_LIB_PATH` (highest priority)
2. Auto-downloaded pdfium (via system library binding)
3. Local `./` directory
4. Clear error guidance if all fail

### Documentation
- **README**: Feature matrix (pdf/corpus/adaptive), build instructions for `cargo install`, platform-specific setup
- **docs/guide/installation.md**: Feature table, build commands for each scenario, pdfium setup instructions
- Users can now disable PDF: `cargo build --no-default-features --features corpus,adaptive`
- crates.io users can specify features: `shadowforge = { version = "0.3", features = ["pdf"] }`

### Code Quality
- Fixed clippy `collapsible_if` and `uninlined_format_args` warnings
- Passes `cargo audit`, `cargo fmt`, `cargo clippy -D warnings`

## Testing
- Verified with `cargo build --features pdf`
- All tests pass
- No new warnings or errors