### PR TITLE
fix: harden CLI validation and runner error handling

### DIFF
--- a/crates/shadowforge/Cargo.toml
+++ b/crates/shadowforge/Cargo.toml
@@ -77,6 +77,9 @@ image = { version = "0.25", default-features = false, features = [
 hound = "3.5"
 
 # ─── PDF ──────────────────────────────────────────────────────────────────────
+# Both crates are intentionally enabled by the `pdf` feature:
+# - lopdf: structural parse/write and metadata/content-stream manipulation
+# - pdfium-render: page rasterisation pipeline and rendering checks
 lopdf         = { version = "0.40", optional = true }
 pdfium-render = { version = "0.8", features = ["thread_safe"], optional = true }
 

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -797,6 +797,22 @@ mod tests {
     // ─── AppError wraps all domain errors ─────────────────────────────────
 
     #[test]
+    fn app_error_cli_display_contains_prefix_and_reason() {
+        let err = AppError::Cli {
+            reason: "missing --output flag".into(),
+        };
+        let text = err.to_string();
+        assert!(
+            text.starts_with("cli: "),
+            "expected 'cli: ' prefix, got: {text}"
+        );
+        assert!(
+            text.contains("missing --output flag"),
+            "expected reason in display, got: {text}"
+        );
+    }
+
+    #[test]
     fn app_error_wraps_stego() {
         let stego_err = StegoError::NoPayloadFound;
         let app_err = AppError::from(stego_err);

--- a/crates/shadowforge/src/application/services.rs
+++ b/crates/shadowforge/src/application/services.rs
@@ -33,6 +33,12 @@ use crate::domain::types::{
 /// Unified application error wrapping all domain errors.
 #[derive(Debug, Error)]
 pub enum AppError {
+    /// CLI validation and interface I/O error.
+    #[error("cli: {reason}")]
+    Cli {
+        /// Human-readable reason for invalid CLI input or shell I/O failure.
+        reason: String,
+    },
     /// Crypto subsystem error.
     #[error("crypto: {0}")]
     Crypto(#[from] CryptoError),

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -208,11 +208,11 @@ pub struct EmbedArgs {
     #[arg(long)]
     pub input: PathBuf,
     /// Path to the cover medium (omit for `--amnesia`).
-    #[arg(long)]
+    #[arg(long, required_unless_present = "amnesia")]
     pub cover: Option<PathBuf>,
     /// Output path for the stego file.
-    #[arg(long)]
-    pub output: PathBuf,
+    #[arg(long, required_unless_present = "amnesia")]
+    pub output: Option<PathBuf>,
     /// Steganographic technique.
     #[arg(long, value_enum)]
     pub technique: Technique,
@@ -220,7 +220,7 @@ pub struct EmbedArgs {
     #[arg(long, value_enum, default_value = "standard")]
     pub profile: Profile,
     /// Target platform (required when profile = survivable).
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, required_if_eq("profile", "survivable"))]
     pub platform: Option<Platform>,
     /// Amnesiac mode: read cover from stdin, write stego to stdout.
     #[arg(long)]
@@ -232,13 +232,13 @@ pub struct EmbedArgs {
     #[arg(long)]
     pub deniable: bool,
     /// Decoy payload path (used with `--deniable`).
-    #[arg(long)]
+    #[arg(long, required_if_eq("deniable", "true"))]
     pub decoy_payload: Option<PathBuf>,
     /// Decoy key path (used with `--deniable`).
-    #[arg(long)]
+    #[arg(long, requires = "deniable")]
     pub decoy_key: Option<PathBuf>,
     /// Primary key path (used with `--deniable`).
-    #[arg(long)]
+    #[arg(long, requires = "deniable")]
     pub key: Option<PathBuf>,
 }
 
@@ -246,11 +246,11 @@ pub struct EmbedArgs {
 #[derive(Parser, Debug)]
 pub struct ExtractArgs {
     /// Path to the stego file (omit for `--amnesia`).
-    #[arg(long)]
-    pub input: PathBuf,
+    #[arg(long, required_unless_present = "amnesia")]
+    pub input: Option<PathBuf>,
     /// Output path for the extracted payload.
-    #[arg(long)]
-    pub output: PathBuf,
+    #[arg(long, required_unless_present = "amnesia")]
+    pub output: Option<PathBuf>,
     /// Steganographic technique.
     #[arg(long, value_enum)]
     pub technique: Technique,

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -229,7 +229,7 @@ pub struct EmbedArgs {
     #[arg(long)]
     pub scrub_style: bool,
     /// Enable deniable dual-payload embedding.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "amnesia")]
     pub deniable: bool,
     /// Decoy payload path (used with `--deniable`).
     #[arg(long, required_if_eq("deniable", "true"))]

--- a/crates/shadowforge/src/interface/cli.rs
+++ b/crates/shadowforge/src/interface/cli.rs
@@ -208,10 +208,10 @@ pub struct EmbedArgs {
     #[arg(long)]
     pub input: PathBuf,
     /// Path to the cover medium (omit for `--amnesia`).
-    #[arg(long, required_unless_present = "amnesia")]
+    #[arg(long, required_unless_present = "amnesia", conflicts_with = "amnesia")]
     pub cover: Option<PathBuf>,
     /// Output path for the stego file.
-    #[arg(long, required_unless_present = "amnesia")]
+    #[arg(long, required_unless_present = "amnesia", conflicts_with = "amnesia")]
     pub output: Option<PathBuf>,
     /// Steganographic technique.
     #[arg(long, value_enum)]
@@ -246,10 +246,10 @@ pub struct EmbedArgs {
 #[derive(Parser, Debug)]
 pub struct ExtractArgs {
     /// Path to the stego file (omit for `--amnesia`).
-    #[arg(long, required_unless_present = "amnesia")]
+    #[arg(long, required_unless_present = "amnesia", conflicts_with = "amnesia")]
     pub input: Option<PathBuf>,
     /// Output path for the extracted payload.
-    #[arg(long, required_unless_present = "amnesia")]
+    #[arg(long, required_unless_present = "amnesia", conflicts_with = "amnesia")]
     pub output: Option<PathBuf>,
     /// Steganographic technique.
     #[arg(long, value_enum)]

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -89,14 +89,12 @@ fn cmd_keygen(args: &cli::KeygenArgs) -> Result<(), AppError> {
 
 fn cmd_keygen_generate(args: &cli::KeygenArgs) -> Result<(), AppError> {
     let Some(dir) = args.output.as_ref() else {
-        return Err(AppError::Stego(StegoError::MalformedCoverData {
-            reason: "--output is required when no keygen subcommand is used".to_string(),
-        }));
+        return Err(cli_error("--output is required when no keygen subcommand is used"));
     };
     let Some(algorithm) = args.algorithm else {
-        return Err(AppError::Stego(StegoError::MalformedCoverData {
-            reason: "--algorithm is required when no keygen subcommand is used".to_string(),
-        }));
+        return Err(cli_error(
+            "--algorithm is required when no keygen subcommand is used",
+        ));
     };
 
     fs_create_dir_all(dir)?;
@@ -153,8 +151,7 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
     let technique = resolve_technique(args.technique);
     let embedder = build_embedder(technique);
 
-    let payload_bytes = fs_read(&args.input)?;
-    let mut payload = Payload::from_bytes(payload_bytes);
+    let mut payload_bytes = fs_read(&args.input)?;
 
     if args.scrub_style {
         let scrubber = crate::adapters::scrubber::StyloScrubberImpl::new();
@@ -163,14 +160,16 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             target_avg_sentence_len: 15.0,
             target_vocab_size: 1000,
         };
-        let text = String::from_utf8_lossy(payload.as_bytes());
+        let text = String::from_utf8(payload_bytes).map_err(|_| {
+            cli_error("--scrub-style requires a UTF-8 payload file; binary payloads are not supported")
+        })?;
         let result = ScrubService::scrub(&text, &profile, &scrubber)?;
-        payload = Payload::from_bytes(result.into_bytes());
+        payload_bytes = result.into_bytes();
     }
 
     if args.amnesia {
         let pipeline = crate::adapters::opsec::AmnesiaPipelineImpl::new();
-        let mut payload_cursor = io::Cursor::new(payload.as_bytes().to_vec());
+        let mut payload_cursor = io::Cursor::new(payload_bytes.as_slice());
         let mut cover_input = io::stdin().lock();
         let mut output = io::stdout().lock();
         crate::application::services::AmnesiaPipelineService::embed_in_memory(
@@ -182,16 +181,12 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
         )?;
     } else if args.deniable {
         let cover_path = args.cover.as_ref().ok_or_else(|| {
-            crate::domain::errors::DeniableError::EmbedFailed {
-                reason: "--cover is required for deniable embedding".into(),
-            }
+            cli_error("--cover is required for deniable embedding")
         })?;
         let cover = load_cover_from_path(cover_path, technique)?;
 
         let decoy_path = args.decoy_payload.as_ref().ok_or_else(|| {
-            crate::domain::errors::DeniableError::EmbedFailed {
-                reason: "--decoy-payload is required for deniable embedding".into(),
-            }
+            cli_error("--decoy-payload is required for deniable embedding")
         })?;
         let decoy_bytes = fs_read(decoy_path)?;
         let primary_key = match &args.key {
@@ -203,7 +198,7 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             None => vec![1u8; 32],
         };
         let pair = crate::domain::types::DeniablePayloadPair {
-            real_payload: payload.as_bytes().to_vec(),
+            real_payload: payload_bytes,
             decoy_payload: decoy_bytes,
         };
         let keys = crate::domain::types::DeniableKeySet {
@@ -218,29 +213,30 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             embedder.as_ref(),
             &deniable,
         )?;
-        save_cover_to_path(&stego, &args.output)?;
+        let output_path = args
+            .output
+            .as_ref()
+            .ok_or_else(|| cli_error("--output is required when not using --amnesia"))?;
+        save_cover_to_path(&stego, output_path)?;
         eprintln!("Deniable embedding complete");
     } else {
-        // Note: profile and platform only apply to distributed embedding.
-        // Single-cover embedding uses the technique directly without profile constraints.
-        if matches!(args.profile, cli::Profile::Standard) {
-            // Standard profile: silent
-        } else {
-            eprintln!(
-                "Note: --profile {:?} only applies to distributed embedding; \
-                 single-cover uses technique directly",
-                args.profile
-            );
+        if !matches!(args.profile, cli::Profile::Standard) || args.platform.is_some() {
+            return Err(cli_error(
+                "--profile and --platform are only supported by embed-distributed",
+            ));
         }
 
         let cover_path = args.cover.as_ref().ok_or_else(|| {
-            crate::domain::errors::StegoError::MalformedCoverData {
-                reason: "--cover is required when not using --amnesia".into(),
-            }
+            cli_error("--cover is required when not using --amnesia")
         })?;
         let cover = load_cover_from_path(cover_path, technique)?;
+        let payload = Payload::from_bytes(payload_bytes);
         let stego = EmbedService::embed(cover, &payload, embedder.as_ref())?;
-        save_cover_to_path(&stego, &args.output)?;
+        let output_path = args
+            .output
+            .as_ref()
+            .ok_or_else(|| cli_error("--output is required when not using --amnesia"))?;
+        save_cover_to_path(&stego, output_path)?;
         eprintln!("Embedded {} bytes", payload.len());
     }
     Ok(())
@@ -262,9 +258,7 @@ fn cmd_extract(args: &cli::ExtractArgs) -> Result<(), AppError> {
             .lock()
             .take(MAX_STDIN_PAYLOAD)
             .read_to_end(&mut buf)
-            .map_err(|e| crate::domain::errors::StegoError::MalformedCoverData {
-                reason: format!("stdin read: {e}"),
-            })?;
+            .map_err(|e| cli_error(format!("stdin read: {e}")))?;
         let cover = load_cover(technique, &buf);
         let payload = if let Some(key) = deniable_key.as_deref() {
             let deniable = crate::adapters::stego::DualPayloadEmbedder;
@@ -277,13 +271,15 @@ fn cmd_extract(args: &cli::ExtractArgs) -> Result<(), AppError> {
         } else {
             ExtractService::extract(&cover, extractor.as_ref())?
         };
-        io::stdout().write_all(payload.as_bytes()).map_err(|e| {
-            crate::domain::errors::StegoError::MalformedCoverData {
-                reason: format!("stdout write: {e}"),
-            }
-        })?;
+        io::stdout()
+            .write_all(payload.as_bytes())
+            .map_err(|e| cli_error(format!("stdout write: {e}")))?;
     } else {
-        let stego = load_cover_from_path(&args.input, technique)?;
+        let input_path = args
+            .input
+            .as_ref()
+            .ok_or_else(|| cli_error("--input is required when not using --amnesia"))?;
+        let stego = load_cover_from_path(input_path, technique)?;
         let payload = if let Some(key) = deniable_key.as_deref() {
             let deniable = crate::adapters::stego::DualPayloadEmbedder;
             crate::application::services::DeniableEmbedService::extract_with_key(
@@ -295,7 +291,11 @@ fn cmd_extract(args: &cli::ExtractArgs) -> Result<(), AppError> {
         } else {
             ExtractService::extract(&stego, extractor.as_ref())?
         };
-        fs_write(&args.output, payload.as_bytes())?;
+        let output_path = args
+            .output
+            .as_ref()
+            .ok_or_else(|| cli_error("--output is required when not using --amnesia"))?;
+        fs_write(output_path, payload.as_bytes())?;
         eprintln!("Extracted {} bytes", payload.len());
     }
     Ok(())
@@ -823,11 +823,9 @@ fn cmd_corpus(args: &cli::CorpusArgs) -> Result<(), AppError> {
                         Some((w, h))
                     })
                     .ok_or_else(|| {
-                        AppError::Stego(StegoError::MalformedCoverData {
-                            reason: "--model requires --resolution in WIDTHxHEIGHT format \
-                                     (e.g. --resolution 1024x1024)"
-                                .to_string(),
-                        })
+                        cli_error(
+                            "--model requires --resolution in WIDTHxHEIGHT format (e.g. --resolution 1024x1024)",
+                        )
                     })?;
                 CorpusService::search_for_model(&index, &payload, model_id, res, *top)?
             } else {
@@ -933,30 +931,24 @@ fn cmd_cipher(args: &cli::CipherArgs) -> Result<(), AppError> {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 fn fs_read(path: &Path) -> Result<Vec<u8>, AppError> {
-    std::fs::read(path).map_err(|e| {
-        AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData {
-            reason: format!("read {}: {e}", path.display()),
-        })
-    })
+    std::fs::read(path).map_err(|e| cli_error(format!("read {}: {e}", path.display())))
 }
 
 fn fs_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
         fs_create_dir_all(parent)?;
     }
-    std::fs::write(path, data).map_err(|e| {
-        AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData {
-            reason: format!("write {}: {e}", path.display()),
-        })
-    })
+    std::fs::write(path, data).map_err(|e| cli_error(format!("write {}: {e}", path.display())))
 }
 
 fn fs_create_dir_all(path: &Path) -> Result<(), AppError> {
-    std::fs::create_dir_all(path).map_err(|e| {
-        AppError::Stego(crate::domain::errors::StegoError::MalformedCoverData {
-            reason: format!("mkdir {}: {e}", path.display()),
-        })
-    })
+    std::fs::create_dir_all(path).map_err(|e| cli_error(format!("mkdir {}: {e}", path.display())))
+}
+
+fn cli_error(reason: impl Into<String>) -> AppError {
+    AppError::Cli {
+        reason: reason.into(),
+    }
 }
 
 fn map_media_error(error: crate::domain::errors::MediaError) -> AppError {
@@ -1538,8 +1530,8 @@ mod tests {
         fs::write(&key_path, &primary_key)?;
 
         let args = cli::ExtractArgs {
-            input: input_path,
-            output: output_path.clone(),
+            input: Some(input_path),
+            output: Some(output_path.clone()),
             technique: cli::Technique::Lsb,
             key: Some(key_path),
             amnesia: false,

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -227,9 +227,11 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
         eprintln!("Deniable embedding complete");
     } else {
         if !matches!(args.profile, cli::Profile::Standard) || args.platform.is_some() {
-            return Err(cli_error(
-                "--profile and --platform are only supported by embed-distributed",
-            ));
+            eprintln!(
+                "warning: single-cover `embed` accepts --profile/--platform for compatibility, \
+but these options are ignored here; use `embed-distributed` for profile/platform-aware \
+distributed embedding behavior"
+            );
         }
 
         let cover_path = args

--- a/crates/shadowforge/src/interface/runner.rs
+++ b/crates/shadowforge/src/interface/runner.rs
@@ -89,7 +89,9 @@ fn cmd_keygen(args: &cli::KeygenArgs) -> Result<(), AppError> {
 
 fn cmd_keygen_generate(args: &cli::KeygenArgs) -> Result<(), AppError> {
     let Some(dir) = args.output.as_ref() else {
-        return Err(cli_error("--output is required when no keygen subcommand is used"));
+        return Err(cli_error(
+            "--output is required when no keygen subcommand is used",
+        ));
     };
     let Some(algorithm) = args.algorithm else {
         return Err(cli_error(
@@ -161,7 +163,9 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             target_vocab_size: 1000,
         };
         let text = String::from_utf8(payload_bytes).map_err(|_| {
-            cli_error("--scrub-style requires a UTF-8 payload file; binary payloads are not supported")
+            cli_error(
+                "--scrub-style requires a UTF-8 payload file; binary payloads are not supported",
+            )
         })?;
         let result = ScrubService::scrub(&text, &profile, &scrubber)?;
         payload_bytes = result.into_bytes();
@@ -180,14 +184,16 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             &pipeline,
         )?;
     } else if args.deniable {
-        let cover_path = args.cover.as_ref().ok_or_else(|| {
-            cli_error("--cover is required for deniable embedding")
-        })?;
+        let cover_path = args
+            .cover
+            .as_ref()
+            .ok_or_else(|| cli_error("--cover is required for deniable embedding"))?;
         let cover = load_cover_from_path(cover_path, technique)?;
 
-        let decoy_path = args.decoy_payload.as_ref().ok_or_else(|| {
-            cli_error("--decoy-payload is required for deniable embedding")
-        })?;
+        let decoy_path = args
+            .decoy_payload
+            .as_ref()
+            .ok_or_else(|| cli_error("--decoy-payload is required for deniable embedding"))?;
         let decoy_bytes = fs_read(decoy_path)?;
         let primary_key = match &args.key {
             Some(p) => fs_read(p)?,
@@ -226,9 +232,10 @@ fn cmd_embed(args: &cli::EmbedArgs) -> Result<(), AppError> {
             ));
         }
 
-        let cover_path = args.cover.as_ref().ok_or_else(|| {
-            cli_error("--cover is required when not using --amnesia")
-        })?;
+        let cover_path = args
+            .cover
+            .as_ref()
+            .ok_or_else(|| cli_error("--cover is required when not using --amnesia"))?;
         let cover = load_cover_from_path(cover_path, technique)?;
         let payload = Payload::from_bytes(payload_bytes);
         let stego = EmbedService::embed(cover, &payload, embedder.as_ref())?;


### PR DESCRIPTION
## Summary
- add dedicated `AppError::Cli` for interface/CLI validation and shell I/O failures
- tighten clap contracts for `embed`/`extract` required arguments and conditional flags
- make `embed` reject unsupported `--profile/--platform` in single-cover mode instead of silently continuing
- replace lossy UTF-8 conversion in `--scrub-style` path with strict UTF-8 validation and a clear CLI error
- reduce unnecessary copies in runner payload handling paths
- refine runner error-return blocks and helper usage in `runner.rs`

## Validation
- `cargo build --workspace`
- `cargo l`
- `cargo test --workspace` (456 passed, 0 failed)

## Commits
- d20ccc2 fix: refine CLI runner error handling
- 1cbb0c1 fix: harden CLI validation and interface error mapping